### PR TITLE
Give me SATCHELS AND BAGS

### DIFF
--- a/code/_globalvars/lists/flavor_misc.dm
+++ b/code/_globalvars/lists/flavor_misc.dm
@@ -159,9 +159,14 @@ GLOBAL_LIST_INIT(security_depts_prefs, list(SEC_DEPT_RANDOM, SEC_DEPT_NONE, SEC_
 #define DDUFFELBAG "Department Duffel Bag"
 GLOBAL_LIST_INIT(backbaglist, list(DBACKPACK, DSATCHEL, DDUFFELBAG, //everything after this point is a non-department backpack
 	"Hiking Backpack" = /obj/item/storage/backpack,
-	"Grey Satchel" = /obj/item/storage/backpack/satchel,
+	"Service Backpack" = /obj/item/storage/backpack/enclave,
 	"Grey Duffel Bag" = /obj/item/storage/backpack/duffelbag,
-	"Leather Satchel" = /obj/item/storage/backpack/satchel/leather,))
+	"Grey Satchel" = /obj/item/storage/backpack/satchel,
+	"Leather Satchel" = /obj/item/storage/backpack/satchel/leather,
+	"Bone Satchel" = /obj/item/storage/backpack/satchel/bone,
+	"Old Satchel" = /obj/item/storage/backpack/satchel/old,
+	"Service Satchel" = /obj/item/storage/backpack/satchel/enclave
+	))
 
 //Suit/Skirt
 #define PREF_SUIT "Jumpsuit"


### PR DESCRIPTION
## About The Pull Request
Re-adds satchel and backpack variety for the backpack you initially spawn in with (not in the loadout screen)

https://github.com/f13nametbd/f13tbd/assets/76122712/0d4f8b83-a3ae-4e7c-8ea2-85d4bfbe5652

## Why It's Good For The Game
More backpacks = Good. Drip customization and variety. Also I can't think of a good reason it was removed in the first place.

## Changelog
- Re-adds the following backpack types as selectable options:
- Service Backpack
- Bone Satchel
- Service Satchel
- Old Satchel