### PR TITLE
silver bow >> titanium bow

### DIFF
--- a/code/datums/components/crafting/recipes/recipes_primal.dm
+++ b/code/datums/components/crafting/recipes/recipes_primal.dm
@@ -194,10 +194,10 @@
 	always_available = FALSE
 
 /datum/crafting_recipe/tribalwar/silverbow
-	name = "Silver Bow"
-	result = /obj/item/gun/ballistic/bow/silver
+	name = "Titanium Bow"
+	result = /obj/item/gun/ballistic/bow/titanium
 	time = 80
-	reqs = list(/obj/item/stack/sheet/mineral/silver = 10,
+	reqs = list(/obj/item/stack/sheet/mineral/titanium = 10,
 				/obj/item/stack/sheet/metal = 10,
 				/obj/item/stack/crafting/metalparts = 5)
 	category = CAT_TRIBAL

--- a/code/modules/projectiles/boxes_magazines/internal/bow.dm
+++ b/code/modules/projectiles/boxes_magazines/internal/bow.dm
@@ -21,8 +21,8 @@
 /obj/item/ammo_box/magazine/internal/bow/sturdy
 	max_ammo = 2 // 3 shots in total
 
-//Silver Bow Ammo
-/obj/item/ammo_box/magazine/internal/bow/silver
+//titanium Bow Ammo
+/obj/item/ammo_box/magazine/internal/bow/titanium
 	max_ammo = 3 // 6 shots in total
 
 //Crossbow Ammo

--- a/code/modules/projectiles/guns/ballistic/bow.dm
+++ b/code/modules/projectiles/guns/ballistic/bow.dm
@@ -122,14 +122,14 @@
 	extra_speed = 300
 
 //Silver Bow
-/obj/item/gun/ballistic/bow/silver
-	name = "silver bow"
+/obj/item/gun/ballistic/bow/titanium
+	name = "titanium bow"
 	desc = "A firm sturdy silver bow created by the earth, its durability and rather strong material allow it to be an excellent option for those looking for the ability to fire more arrows than normally."
 	icon_state = "pipebow"
 	item_state = "pipebow"
 	icon_prefix = "pipebow"
 	force = 15
-	mag_type = /obj/item/ammo_box/magazine/internal/bow/silver
+	mag_type = /obj/item/ammo_box/magazine/internal/bow/titanium
 	fire_delay = 1.5
 
 //Crossbow


### PR DESCRIPTION


## About The Pull Request

silver bow is now a titanium bow. crafted from titanium. no stat changes

## Why It's Good For The Game

silver is really rare, doubly so as tribal since you have to 1. beg/borrow/steal a mining scanner and 2. handsmelt all the ore using welders

titanium is comparatively much easier to get (recycle salvage, HQ metal parts etc).

for a bow that's barely better than the dirt-cheap sturdy bow, it should be only slightly harder to acquire, instead of something that needs you to go out of the way for it completely

## Pre-Merge Checklist

- [ ] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [ ] You documented all of your changes.


## Changelog


:cl:
tweak: the silver bow is now the titanium bow, made from titanium instead of silver
/:cl:

