### PR TITLE
miscellaneous map changes

### DIFF
--- a/_maps/map_files/Pahrump-Sunset/Mountain-Range.dmm
+++ b/_maps/map_files/Pahrump-Sunset/Mountain-Range.dmm
@@ -632,13 +632,6 @@
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier1,
 /turf/open/floor/f13/wood,
 /area/f13/building)
-"fS" = (
-/obj/effect/decal/remains/human,
-/obj/structure/timeddoor/sixtyminute,
-/turf/open/indestructible/ground/outside/road{
-	icon_state = "horizontalinnermain0"
-	},
-/area/f13/tunnel)
 "fT" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/small{
@@ -1781,10 +1774,6 @@
 /obj/structure/closet/crate/grave,
 /turf/open/indestructible/ground/outside/snow,
 /area/f13/mountain_area)
-"oF" = (
-/obj/structure/timeddoor/sixtyminute,
-/turf/closed/wall/f13/tunnel,
-/area/f13/tunnel)
 "oG" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood/wood_fancy,
@@ -2286,12 +2275,6 @@
 /obj/structure/table/reinforced,
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
 /area/f13/enclave)
-"sn" = (
-/obj/structure/timeddoor/sixtyminute,
-/turf/open/indestructible/ground/outside/road{
-	icon_state = "horizontalinnermain0"
-	},
-/area/f13/tunnel)
 "sp" = (
 /obj/effect/decal/marking{
 	icon_state = "doubleverticalcorroded"
@@ -4159,15 +4142,6 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/dark,
 /area/f13/enclave)
-"Hn" = (
-/obj/effect/decal/marking{
-	icon_state = "doublevertical"
-	},
-/obj/structure/timeddoor/sixtyminute,
-/turf/open/indestructible/ground/outside/road{
-	icon_state = "horizontalinnermain0"
-	},
-/area/f13/tunnel)
 "Hr" = (
 /obj/machinery/light/floor,
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
@@ -68192,7 +68166,7 @@ Hc
 lZ
 ov
 WS
-oF
+dE
 fa
 dE
 dE
@@ -68449,7 +68423,7 @@ Ry
 Ry
 Ry
 iH
-sn
+ie
 ie
 ie
 ie
@@ -68706,7 +68680,7 @@ Ry
 ic
 jo
 to
-sn
+ie
 ie
 ie
 ZD
@@ -68963,7 +68937,7 @@ Ry
 jo
 jo
 to
-fS
+ZD
 ie
 ie
 ie
@@ -69220,7 +69194,7 @@ Ry
 gd
 Ry
 ex
-sn
+ie
 ie
 ie
 ie
@@ -69477,7 +69451,7 @@ mV
 Vg
 rt
 mK
-Hn
+pd
 pd
 sp
 vl
@@ -69734,7 +69708,7 @@ Ry
 GS
 Ry
 iH
-sn
+ie
 ie
 ie
 ie
@@ -69991,7 +69965,7 @@ Ry
 jo
 jo
 to
-sn
+ie
 ie
 ie
 ie
@@ -70248,7 +70222,7 @@ Ry
 Ry
 jo
 to
-sn
+ie
 ie
 ZD
 ie
@@ -70505,7 +70479,7 @@ Ry
 Ry
 Ry
 ex
-sn
+ie
 ie
 ie
 ie
@@ -70762,7 +70736,7 @@ wF
 mD
 Lb
 WS
-oF
+dE
 fa
 dE
 dE

--- a/_maps/map_files/Pahrump-Sunset/Pahrump-Sunset.dmm
+++ b/_maps/map_files/Pahrump-Sunset/Pahrump-Sunset.dmm
@@ -34,7 +34,7 @@
 /area/f13/caves)
 "aao" = (
 /turf/open/indestructible/ground/outside/road{
-	icon_state = "horizontalinnermain0"
+	icon_state = "verticalrightborderleft0"
 	},
 /area/f13/tunnel/northeast)
 "aap" = (
@@ -55,7 +55,7 @@
 /area/f13/tunnel/sub)
 "aas" = (
 /turf/open/indestructible/ground/outside/road{
-	icon_state = "horizontalinnermain2"
+	icon_state = "verticalinnermain0"
 	},
 /area/f13/tunnel/northeast)
 "aat" = (
@@ -63,7 +63,7 @@
 	name = "Bighorn Exterior"
 	},
 /turf/open/indestructible/ground/outside/road{
-	icon_state = "verticalinnermain0"
+	icon_state = "horizontalinnermain0"
 	},
 /area/f13/wasteland/west)
 "aau" = (
@@ -77,6 +77,9 @@
 /obj/structure/barricade/bars{
 	max_integrity = 800;
 	obj_integrity = 800
+	},
+/obj/effect/turf_decal/weather/dirt{
+	dir = 4
 	},
 /turf/open/indestructible/ground/outside/water,
 /area/f13/caves)
@@ -103,7 +106,7 @@
 	icon_state = "doublevertical"
 	},
 /turf/open/indestructible/ground/outside/road{
-	icon_state = "horizontalinnermain0"
+	icon_state = "verticalinnermain0"
 	},
 /area/f13/tunnel/northeast)
 "aaA" = (
@@ -224,7 +227,7 @@
 "aaS" = (
 /obj/effect/spawner/lootdrop/f13/junkspawners,
 /turf/open/indestructible/ground/outside/road{
-	icon_state = "horizontalinnermain0"
+	icon_state = "verticalinnermain1"
 	},
 /area/f13/tunnel/northeast)
 "aaT" = (
@@ -669,7 +672,7 @@
 	icon_state = "doubleverticalcorroded"
 	},
 /turf/open/indestructible/ground/outside/road{
-	icon_state = "horizontalinnermain0"
+	icon_state = "verticalinnermain0"
 	},
 /area/f13/tunnel/northeast)
 "acB" = (
@@ -711,7 +714,7 @@
 	icon_state = "doubleverticalcorroded"
 	},
 /turf/open/indestructible/ground/outside/road{
-	icon_state = "horizontalinnermain0"
+	icon_state = "verticalinnermain0"
 	},
 /area/f13/wasteland/east)
 "acI" = (
@@ -839,13 +842,11 @@
 	},
 /area/f13/wasteland/east)
 "add" = (
-/obj/effect/decal/marking{
-	icon_state = "doublevertical"
-	},
+/obj/structure/barricade/wooden,
 /turf/open/indestructible/ground/outside/road{
-	icon_state = "horizontalinnermain0"
+	icon_state = "verticalrightborderleft0"
 	},
-/area/f13/wasteland/east)
+/area/f13/wasteland/hospital)
 "ade" = (
 /obj/structure/fence,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -1396,7 +1397,7 @@
 	icon_state = "doubleverticaldegraded"
 	},
 /turf/open/indestructible/ground/outside/road{
-	icon_state = "horizontalinnermain0"
+	icon_state = "verticalinnermain0"
 	},
 /area/f13/wasteland/east)
 "aft" = (
@@ -1626,7 +1627,7 @@
 	icon_state = "doubleverticalbottom"
 	},
 /turf/open/indestructible/ground/outside/road{
-	icon_state = "horizontalinnermain0"
+	icon_state = "verticalinnermain0"
 	},
 /area/f13/wasteland/east)
 "agk" = (
@@ -1678,10 +1679,13 @@
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland/west)
 "agA" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/landmark/observer_start,
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland/valley)
+/obj/effect/decal/marking{
+	icon_state = "doubleverticaltop"
+	},
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "verticalinnermain1"
+	},
+/area/f13/wasteland/east)
 "agB" = (
 /obj/machinery/shower{
 	dir = 8
@@ -1716,7 +1720,7 @@
 	icon_state = "doubleverticaltop"
 	},
 /turf/open/indestructible/ground/outside/road{
-	icon_state = "horizontalinnermain0"
+	icon_state = "verticalinnermain0"
 	},
 /area/f13/wasteland/east)
 "agI" = (
@@ -2166,12 +2170,10 @@
 /turf/open/indestructible/ground/outside/sidewalk,
 /area/f13/wasteland/train)
 "ais" = (
-/obj/structure/flora/tree/tall{
-	icon_state = "tree_2"
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "verticalinnermain2"
 	},
-/obj/structure/flora/tree/tall,
-/turf/open/indestructible/ground/outside/desert,
-/area/f13/ruins)
+/area/f13/tunnel/northeast)
 "aiw" = (
 /mob/living/simple_animal/hostile/ghoul/reaver,
 /turf/open/indestructible/ground/outside/dirt{
@@ -2288,7 +2290,9 @@
 /area/f13/wasteland/west)
 "aiR" = (
 /mob/living/simple_animal/hostile/eyebot,
-/turf/open/indestructible/ground/outside/sidewalk,
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "horizontaloutermain0"
+	},
 /area/f13/wasteland/west)
 "aiS" = (
 /obj/item/ammo_casing/caseless{
@@ -3140,7 +3144,7 @@
 	icon_state = "goo8"
 	},
 /turf/open/indestructible/ground/outside/road{
-	icon_state = "horizontalinnermain0"
+	icon_state = "verticalrightborderleft1"
 	},
 /area/f13/wasteland/east)
 "amh" = (
@@ -3769,7 +3773,7 @@
 "aoU" = (
 /obj/item/candle/tribal_torch,
 /turf/open/indestructible/ground/outside/road{
-	icon_state = "horizontalinnermain0"
+	icon_state = "horizontalbottombordertop0"
 	},
 /area/f13/wasteland/east)
 "aoV" = (
@@ -3935,12 +3939,10 @@
 /turf/open/floor/carpet/red,
 /area/f13/bar/heaven)
 "apF" = (
-/obj/structure/simple_door/room{
-	name = "Heaven's Night"
-	},
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
 	},
+/obj/structure/simple_door/metal,
 /turf/open/floor/wood/wood_mosaic/wood_mosaic_dark,
 /area/f13/bar/heaven)
 "apH" = (
@@ -4120,17 +4122,14 @@
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
 	},
-/obj/machinery/light/sign/heaven{
-	pixel_y = 32
-	},
-/turf/open/floor/carpet/red,
+/turf/open/floor/wood,
 /area/f13/bar/heaven)
 "aqw" = (
 /obj/machinery/microwave/stove,
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
 	},
-/turf/open/floor/carpet/red,
+/turf/open/floor/wood,
 /area/f13/bar/heaven)
 "aqz" = (
 /obj/structure/chair{
@@ -4251,7 +4250,7 @@
 	color = "#363636"
 	},
 /obj/machinery/chem_dispenser/drinks/beer/fullupgrade,
-/turf/open/floor/carpet/red,
+/turf/open/floor/wood,
 /area/f13/bar/heaven)
 "aqW" = (
 /obj/structure/fence,
@@ -4471,7 +4470,9 @@
 	color = "#363636"
 	},
 /obj/machinery/light/floor,
-/turf/open/floor/carpet/red,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	name = "metal plating"
+	},
 /area/f13/bar/heaven)
 "arV" = (
 /obj/structure/destructible/tribal_torch/wall/lit{
@@ -5305,7 +5306,7 @@
 	color = "#363636"
 	},
 /obj/machinery/chem_dispenser/drinks/fullupgrade,
-/turf/open/floor/carpet/red,
+/turf/open/floor/wood,
 /area/f13/bar/heaven)
 "avk" = (
 /obj/effect/decal/cleanable/oil{
@@ -6170,12 +6171,12 @@
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
 	},
-/turf/open/floor/carpet/red,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	name = "metal plating"
+	},
 /area/f13/bar/heaven)
 "axZ" = (
-/obj/structure/table/reinforced,
-/obj/machinery/light/floor,
-/obj/item/broken_bottle,
+/obj/structure/table/wood/settler,
 /turf/open/floor/carpet/red,
 /area/f13/bar/heaven)
 "ayb" = (
@@ -6355,7 +6356,7 @@
 	icon_state = "dottedverticaldegraded"
 	},
 /turf/open/indestructible/ground/outside/road{
-	icon_state = "horizontalinnermain0"
+	icon_state = "verticalinnermain0"
 	},
 /area/f13/wasteland/east)
 "ayE" = (
@@ -7316,7 +7317,7 @@
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
 	},
-/turf/open/floor/carpet/red,
+/turf/open/floor/wood,
 /area/f13/bar/heaven)
 "aBL" = (
 /obj/effect/decal/cleanable/dirt{
@@ -7326,7 +7327,7 @@
 /turf/open/floor/plasteel/f13/vault_floor/neutral/white/side,
 /area/f13/building/mall)
 "aBM" = (
-/obj/structure/chair/sofa/corp/left{
+/obj/structure/chair/sofa/left{
 	dir = 4
 	},
 /turf/open/floor/carpet/red,
@@ -7941,10 +7942,18 @@
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
 	},
-/turf/open/floor/carpet/red,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	name = "metal plating"
+	},
 /area/f13/bar/heaven)
 "aDR" = (
-/obj/structure/chair/stool/retro,
+/obj/structure/table/wood/settler,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/item/melee/onehanded/slavewhip{
+	name = "whip"
+	},
 /turf/open/floor/carpet/red,
 /area/f13/bar/heaven)
 "aDS" = (
@@ -8710,7 +8719,9 @@
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
 	},
-/turf/open/floor/carpet/red,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	name = "metal plating"
+	},
 /area/f13/bar/heaven)
 "aGh" = (
 /obj/item/ammo_casing/c10mm,
@@ -9110,7 +9121,9 @@
 /obj/structure/table/reinforced{
 	color = "#c1b6a5"
 	},
-/turf/open/floor/carpet/red,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	name = "metal plating"
+	},
 /area/f13/bar/heaven)
 "aHy" = (
 /obj/structure/simple_door/room,
@@ -9411,9 +9424,13 @@
 	},
 /area/f13/building/firestation)
 "aIA" = (
-/obj/structure/nest/mirelurk,
-/turf/open/floor/plasteel/f13/vault_floor/white,
-/area/f13/village)
+/obj/effect/decal/marking{
+	icon_state = "doubleverticalcorroded"
+	},
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "verticalinnermain1"
+	},
+/area/f13/wasteland/east)
 "aIB" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -9746,7 +9763,9 @@
 	dir = 6
 	},
 /obj/machinery/light/floor,
-/turf/open/floor/carpet/red,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	name = "metal plating"
+	},
 /area/f13/bar/heaven)
 "aJP" = (
 /obj/structure/fence/wooden{
@@ -9850,7 +9869,7 @@
 "aKh" = (
 /obj/item/storage/trash_stack,
 /turf/open/indestructible/ground/outside/road{
-	icon_state = "horizontalinnermain0"
+	icon_state = "verticalleftborderright0"
 	},
 /area/f13/wasteland/east)
 "aKi" = (
@@ -10138,12 +10157,10 @@
 /turf/open/floor/f13/wood,
 /area/f13/building/mall)
 "aLh" = (
-/obj/structure/chair/sofa/corp/corner{
-	dir = 1
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "horizontalbottombordertop0"
 	},
-/obj/machinery/light/floor,
-/turf/open/floor/carpet/red,
-/area/f13/bar/heaven)
+/area/f13/tunnel/southeast)
 "aLi" = (
 /obj/structure/window/fulltile/house{
 	icon_state = "housewindowvertical"
@@ -10651,8 +10668,8 @@
 /turf/open/floor/carpet,
 /area/f13/building/mall)
 "aMV" = (
-/obj/structure/table/reinforced,
 /obj/machinery/light/floor,
+/obj/structure/table/wood/settler,
 /turf/open/floor/carpet/red,
 /area/f13/bar/heaven)
 "aMW" = (
@@ -10722,10 +10739,9 @@
 /turf/open/floor/plasteel/f13/vault_floor/white,
 /area/f13/building/hospital)
 "aNg" = (
-/obj/structure/simple_door/room{
-	name = "Heaven's Night"
-	},
-/turf/open/floor/wood/wood_mosaic/wood_mosaic_dark,
+/obj/item/storage/pill_bottle/lsd,
+/obj/structure/table/wood/settler,
+/turf/open/floor/carpet/red,
 /area/f13/bar/heaven)
 "aNh" = (
 /obj/effect/decal/remains/human,
@@ -11087,7 +11103,7 @@
 /turf/open/floor/plasteel/f13/vault_floor/white,
 /area/f13/building/hospital)
 "aOk" = (
-/obj/structure/chair/sofa/corp/right{
+/obj/structure/chair/sofa/right{
 	dir = 8
 	},
 /turf/open/floor/carpet/red,
@@ -11105,7 +11121,7 @@
 	name = "Ambulance Bay 2"
 	},
 /turf/open/indestructible/ground/outside/road{
-	icon_state = "verticalrightborderleft2"
+	icon_state = "verticalrightborderleft0"
 	},
 /area/f13/building/hospital)
 "aOn" = (
@@ -11579,7 +11595,7 @@
 	icon_state = "dottedverticalcorroded"
 	},
 /turf/open/indestructible/ground/outside/road{
-	icon_state = "horizontalinnermain2"
+	icon_state = "verticalinnermain0"
 	},
 /area/f13/wasteland/east)
 "aPO" = (
@@ -11643,6 +11659,14 @@
 	icon_state = "horizontalinnermain0"
 	},
 /area/f13/wasteland/firestation)
+"aPZ" = (
+/obj/effect/decal/marking{
+	icon_state = "doublevertical"
+	},
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "verticalinnermain2"
+	},
+/area/f13/tunnel/northeast)
 "aQa" = (
 /obj/structure/barricade/wooden,
 /turf/open/indestructible/ground/outside/road{
@@ -11672,10 +11696,9 @@
 	},
 /area/f13/building)
 "aQe" = (
-/obj/structure/chair/sofa/corp{
-	dir = 1
+/turf/open/floor/f13{
+	icon_state = "stagestairs"
 	},
-/turf/open/floor/carpet/red,
 /area/f13/bar/heaven)
 "aQf" = (
 /obj/structure/simple_door/bunker,
@@ -12755,7 +12778,7 @@
 	dir = 4
 	},
 /turf/open/indestructible/ground/outside/road{
-	icon_state = "horizontalinnermain0"
+	icon_state = "verticalleftborderright0"
 	},
 /area/f13/wasteland/east)
 "aTU" = (
@@ -13791,7 +13814,7 @@
 	icon_state = "doublevertical"
 	},
 /turf/open/indestructible/ground/outside/road{
-	icon_state = "horizontalinnermain2"
+	icon_state = "verticalinnermain0"
 	},
 /area/f13/wasteland/east)
 "aXw" = (
@@ -14009,7 +14032,6 @@
 /turf/closed/wall/f13/store,
 /area/f13/building/bighornbunker)
 "aYl" = (
-/obj/effect/landmark/start/f13/khan_court,
 /obj/structure/bed/mattress/pregame,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/bar/heaven)
@@ -14028,12 +14050,11 @@
 /turf/open/floor/wood/wood_wide,
 /area/f13/city/bighorn)
 "aYo" = (
-/obj/structure/junk/jukebox,
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
+/obj/effect/decal/marking,
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "horizontaltopborderbottom0"
 	},
-/turf/open/floor/wood/wood_mosaic/wood_mosaic_dark,
-/area/f13/bar/heaven)
+/area/f13/wasteland/heaven)
 "aYp" = (
 /obj/structure/rack,
 /obj/item/cultivator,
@@ -14264,17 +14285,23 @@
 	},
 /area/f13/building/bighornbunker)
 "aYV" = (
-/obj/structure/railing{
-	dir = 1
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
 	},
-/obj/structure/chair/sofa/corp/corner{
+/obj/structure/chair/booth{
 	dir = 4
 	},
-/obj/machinery/light/floor,
-/turf/open/floor/carpet/red,
+/obj/structure/railing{
+	layer = 3.3;
+	plane = -3;
+	dir = 10
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	name = "metal plating"
+	},
 /area/f13/bar/heaven)
 "aYW" = (
-/obj/structure/chair/sofa/corp/right{
+/obj/structure/chair/sofa/right{
 	dir = 4
 	},
 /turf/open/floor/carpet/red,
@@ -14283,14 +14310,13 @@
 /turf/closed/mineral/random/high_chance,
 /area/f13/bar/heaven)
 "aYZ" = (
-/obj/machinery/light/small{
-	dir = 1;
-	light_color = "red"
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
 	},
-/obj/structure/railing{
-	dir = 8
+/obj/structure/chair/sofa/corp/left{
+	dir = 4
 	},
-/turf/open/floor/vault,
+/turf/open/floor/wood/wood_mosaic/wood_mosaic_dark,
 /area/f13/bar/heaven)
 "aZb" = (
 /obj/item/storage/trash_stack,
@@ -14522,8 +14548,10 @@
 	},
 /area/f13/building/mall)
 "aZW" = (
-/obj/structure/railing/dancing_pole/top,
-/turf/open/floor/vault,
+/obj/structure/railing/dancing_pole,
+/turf/open/floor/plasteel/cult{
+	name = "stage floor"
+	},
 /area/f13/bar/heaven)
 "aZY" = (
 /obj/structure/sink{
@@ -14651,10 +14679,13 @@
 /turf/open/indestructible/ground/outside/savannah/bottomcenter,
 /area/f13/building/nanotrasen)
 "baC" = (
-/obj/structure/railing{
-	dir = 8
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
 	},
-/turf/open/floor/vault,
+/obj/structure/chair/sofa/corp/right{
+	dir = 4
+	},
+/turf/open/floor/wood/wood_mosaic/wood_mosaic_dark,
 /area/f13/bar/heaven)
 "baD" = (
 /obj/item/candle/tribal_torch,
@@ -14664,8 +14695,14 @@
 	},
 /area/f13/wasteland/nanotrasen)
 "baE" = (
-/obj/effect/turf_decal/huge/khan,
-/turf/open/floor/vault,
+/obj/machinery/light/floor,
+/obj/structure/railing{
+	dir = 10;
+	layer = 3.5
+	},
+/turf/open/floor/plasteel/cult{
+	name = "stage floor"
+	},
 /area/f13/bar/heaven)
 "baF" = (
 /obj/structure/flora/ausbushes/leafybush,
@@ -14727,7 +14764,12 @@
 	},
 /area/f13/building/bighornbunker)
 "baO" = (
-/turf/open/floor/vault,
+/obj/structure/railing{
+	dir = 8
+	},
+/turf/open/floor/plasteel/cult{
+	name = "stage floor"
+	},
 /area/f13/bar/heaven)
 "baR" = (
 /obj/structure/rack,
@@ -14785,10 +14827,13 @@
 	},
 /area/f13/wasteland/east)
 "bbf" = (
-/obj/structure/railing{
-	dir = 4
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
 	},
-/turf/open/floor/vault,
+/obj/structure/chair/sofa/corp/left{
+	dir = 8
+	},
+/turf/open/floor/wood/wood_mosaic/wood_mosaic_dark,
 /area/f13/bar/heaven)
 "bbi" = (
 /obj/structure/bed,
@@ -14798,11 +14843,13 @@
 /turf/open/floor/f13/wood,
 /area/f13/village)
 "bbm" = (
-/obj/machinery/light/floor,
-/obj/structure/railing{
-	dir = 10
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
 	},
-/turf/open/floor/vault,
+/obj/structure/chair/sofa/corp/corner{
+	dir = 1
+	},
+/turf/open/floor/wood/wood_mosaic/wood_mosaic_dark,
 /area/f13/bar/heaven)
 "bbo" = (
 /obj/structure/chair/stool{
@@ -15230,8 +15277,13 @@
 /turf/open/floor/f13/wood,
 /area/f13/village)
 "bcO" = (
-/obj/structure/railing,
-/turf/open/floor/vault,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/structure/chair/sofa/corp/right{
+	dir = 1
+	},
+/turf/open/floor/wood/wood_mosaic/wood_mosaic_dark,
 /area/f13/bar/heaven)
 "bcP" = (
 /obj/structure/chair{
@@ -15388,11 +15440,13 @@
 /turf/open/indestructible/ground/outside/sidewalk,
 /area/f13/wasteland/museum)
 "bdq" = (
-/obj/machinery/light/floor,
-/obj/structure/railing{
-	dir = 6
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
 	},
-/turf/open/floor/vault,
+/obj/structure/chair/sofa/corp/corner{
+	dir = 8
+	},
+/turf/open/floor/wood/wood_mosaic/wood_mosaic_dark,
 /area/f13/bar/heaven)
 "bds" = (
 /obj/structure/closet/fridge,
@@ -16188,7 +16242,7 @@
 "bfT" = (
 /obj/structure/bus_door,
 /turf/open/indestructible/ground/outside/road{
-	icon_state = "horizontalinnermain0"
+	icon_state = "horizontaltopborderbottom0"
 	},
 /area/f13/wasteland/east)
 "bfU" = (
@@ -16432,14 +16486,13 @@
 /turf/open/floor/f13,
 /area/f13/building)
 "bgJ" = (
-/obj/machinery/light/small{
-	dir = 1;
-	light_color = "red"
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
 	},
-/obj/structure/railing{
-	dir = 4
+/obj/structure/chair/sofa/corp/right{
+	dir = 8
 	},
-/turf/open/floor/vault,
+/turf/open/floor/wood/wood_mosaic/wood_mosaic_dark,
 /area/f13/bar/heaven)
 "bgK" = (
 /obj/structure/stairs/north{
@@ -16653,11 +16706,10 @@
 	},
 /area/f13/building/nanotrasen)
 "bhI" = (
-/obj/structure/chair/sofa/corp/left{
-	dir = 1
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "horizontaltopborderbottom0"
 	},
-/turf/open/floor/carpet/red,
-/area/f13/bar/heaven)
+/area/f13/tunnel/southeast)
 "bhJ" = (
 /obj/structure/chair/office/dark,
 /turf/open/floor/f13,
@@ -17969,6 +18021,12 @@
 	},
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland/west)
+"bmb" = (
+/obj/effect/turf_decal/weather/dirt{
+	dir = 10
+	},
+/turf/open/indestructible/ground/outside/water,
+/area/f13/caves)
 "bmc" = (
 /turf/closed/indestructible/rock,
 /area/f13/tunnel/sub)
@@ -18503,7 +18561,9 @@
 /area/f13/building)
 "bog" = (
 /mob/living/simple_animal/hostile/handy/protectron,
-/turf/open/indestructible/ground/outside/sidewalk,
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "horizontaloutermain0"
+	},
 /area/f13/wasteland/west)
 "boh" = (
 /obj/structure/noticeboard{
@@ -19140,6 +19200,7 @@
 /area/f13/building)
 "brn" = (
 /obj/structure/sink/deep_water,
+/obj/effect/turf_decal/weather/dirt,
 /turf/open/indestructible/ground/outside/water,
 /area/f13/wasteland/train)
 "brv" = (
@@ -19676,6 +19737,15 @@
 /obj/structure/window/fulltile/store,
 /turf/open/floor/wood/wood_common,
 /area/f13/followers)
+"bwn" = (
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/structure/chair/sofa/corp/left{
+	dir = 1
+	},
+/turf/open/floor/wood/wood_mosaic/wood_mosaic_dark,
+/area/f13/bar/heaven)
 "bwr" = (
 /obj/structure/bed,
 /obj/item/bedsheet{
@@ -20596,7 +20666,7 @@
 "bGa" = (
 /obj/structure/barricade/sandbags,
 /turf/open/indestructible/ground/outside/road{
-	icon_state = "horizontalinnermain2left"
+	icon_state = "verticalrightborderleft0"
 	},
 /area/f13/wasteland/massfusion)
 "bGj" = (
@@ -20877,6 +20947,12 @@
 	icon_state = "horizontalinnermain1"
 	},
 /area/f13/wasteland/west)
+"bOD" = (
+/obj/effect/turf_decal/weather/dirt{
+	dir = 1
+	},
+/turf/open/indestructible/ground/outside/water,
+/area/f13/wasteland/train)
 "bOE" = (
 /obj/effect/decal/cleanable/chem_pile,
 /turf/open/floor/plasteel/f13{
@@ -20922,7 +20998,8 @@
 	},
 /area/f13/wasteland/massfusion)
 "bQL" = (
-/obj/structure/chair/sofa/corp{
+/obj/machinery/light/floor,
+/obj/structure/chair/sofa/corner{
 	dir = 4
 	},
 /turf/open/floor/carpet/red,
@@ -21079,13 +21156,17 @@
 	},
 /obj/effect/spawner/lootdrop/f13/cash_random_low,
 /turf/open/indestructible/ground/outside/road{
-	icon_state = "horizontalinnermain0"
+	icon_state = "verticalinnermain0"
 	},
 /area/f13/wasteland/east)
 "bTz" = (
 /obj/structure/stone_tile/block/cracked,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/city/bighorn)
+"bTD" = (
+/obj/structure/chair/sofa/left,
+/turf/open/floor/carpet/red,
+/area/f13/bar/heaven)
 "bTE" = (
 /obj/effect/turf_decal/weather/dirt,
 /turf/open/indestructible/ground/outside/graveldirt{
@@ -21638,7 +21719,7 @@
 /obj/structure/flora/tree/tall{
 	icon_state = "tree_3"
 	},
-/turf/open/indestructible/ground/outside/dirt,
+/turf/open/floor/plating/dirt,
 /area/f13/wasteland/train)
 "cbx" = (
 /obj/machinery/light{
@@ -22788,10 +22869,13 @@
 /turf/open/indestructible/ground/outside/water,
 /area/f13/caves)
 "cqC" = (
-/turf/open/indestructible/ground/outside/ruins{
-	icon_state = "rubblecorner"
+/obj/effect/decal/marking{
+	icon_state = "doubleverticaldegraded"
 	},
-/area/f13/wasteland/nanotrasen)
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "verticalinnermain1"
+	},
+/area/f13/wasteland/east)
 "cqD" = (
 /obj/structure/table/wood,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/hobo,
@@ -22827,6 +22911,10 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13/wood,
 /area/f13/building/museum)
+"cqQ" = (
+/obj/structure/flora/grass/wasteland,
+/turf/open/floor/plating/dirt,
+/area/f13/wasteland/train)
 "cqR" = (
 /obj/structure/table/wood,
 /obj/effect/spawner/lootdrop/f13/cash_random_low,
@@ -23052,11 +23140,10 @@
 /turf/open/floor/f13/wood,
 /area/f13/building/museum)
 "csY" = (
-/obj/structure/window/fulltile/store{
-	icon_state = "ruinswindowbrokenvertical"
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "horizontalinnermain3"
 	},
-/turf/open/floor/f13/wood,
-/area/f13/building)
+/area/f13/wasteland/train)
 "csZ" = (
 /obj/effect/decal/cleanable/blood/old,
 /turf/open/floor/f13/wood,
@@ -24062,6 +24149,12 @@
 /obj/structure/barricade/wooden/strong,
 /turf/closed/wall/f13/wood,
 /area/f13/caves)
+"cSh" = (
+/obj/effect/landmark/start/f13/outsider,
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "horizontalbottombordertop0"
+	},
+/area/f13/tunnel/southeast)
 "cSt" = (
 /obj/effect/decal/marking{
 	icon_state = "doublehorizontal"
@@ -24103,7 +24196,9 @@
 	dir = 4
 	},
 /obj/effect/decal/cleanable/oil,
-/turf/open/indestructible/ground/outside/sidewalk,
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "horizontaloutermain0"
+	},
 /area/f13/wasteland/west)
 "cUr" = (
 /obj/structure/rack,
@@ -24205,6 +24300,14 @@
 	},
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland/museum)
+"cZr" = (
+/obj/effect/decal/marking{
+	icon_state = "doubleverticaldegraded"
+	},
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "verticalinnermain1"
+	},
+/area/f13/wasteland/train)
 "daa" = (
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "verticalleftborderright0"
@@ -24437,10 +24540,9 @@
 /area/f13/building)
 "dip" = (
 /turf/open/indestructible/ground/outside/road{
-	dir = 1;
-	icon_state = "innermaincornerouter"
+	icon_state = "verticalleftborderright1"
 	},
-/area/f13/wasteland/east)
+/area/f13/tunnel/northeast)
 "diz" = (
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland/bighorn)
@@ -24640,6 +24742,11 @@
 /obj/structure/barricade/wooden/planks/pregame,
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "verticalleftborderright0"
+	},
+/area/f13/wasteland/east)
+"dpL" = (
+/turf/open/floor/plating/f13/outside/road{
+	icon_state = "horizontaltopborderbottom1"
 	},
 /area/f13/wasteland/east)
 "dpQ" = (
@@ -24880,7 +24987,7 @@
 	dir = 4
 	},
 /turf/open/indestructible/ground/outside/road{
-	icon_state = "horizontalinnermain0"
+	icon_state = "verticalleftborderright0"
 	},
 /area/f13/wasteland/hospital)
 "dxq" = (
@@ -25017,6 +25124,10 @@
 	icon_state = "dirt"
 	},
 /area/f13/wasteland/quarry)
+"dAY" = (
+/obj/machinery/vending/cigarette,
+/turf/open/floor/carpet/red,
+/area/f13/bar/heaven)
 "dBo" = (
 /obj/machinery/light/sign/shed{
 	pixel_y = 30
@@ -25046,13 +25157,18 @@
 	icon_state = "darkrustysolid"
 	},
 /area/f13/radiation)
-"dCu" = (
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
+"dCh" = (
+/obj/structure/chair/sofa/left{
+	dir = 1
 	},
-/obj/effect/decal/cleanable/ash,
-/turf/open/floor/wood/wood_mosaic/wood_mosaic_dark,
+/turf/open/floor/carpet/red,
 /area/f13/bar/heaven)
+"dCu" = (
+/obj/effect/landmark/start/f13/wastelander,
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "horizontalbottombordertop0"
+	},
+/area/f13/tunnel/southeast)
 "dCD" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/bot_assembly/cleanbot,
@@ -25305,7 +25421,7 @@
 	icon_state = "dottedverticalcorroded"
 	},
 /turf/open/indestructible/ground/outside/road{
-	icon_state = "horizontalinnermain0"
+	icon_state = "verticalinnermain0"
 	},
 /area/f13/wasteland/train)
 "dJk" = (
@@ -25497,6 +25613,14 @@
 /obj/structure/junk/arcade,
 /turf/open/indestructible/ground/outside/sidewalk,
 /area/f13/wasteland/bighorn)
+"dPF" = (
+/obj/structure/obstacle/barbedwire{
+	dir = 4
+	},
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "verticalinnermain0"
+	},
+/area/f13/wasteland/hospital)
 "dPY" = (
 /obj/structure/table/reinforced,
 /obj/effect/spawner/lootdrop/f13/medical/surgical,
@@ -25564,6 +25688,11 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/misc/bar,
 /area/f13/city/bighorn)
+"dSD" = (
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "verylittleshadowright"
+	},
+/area/f13/wasteland/heaven)
 "dSE" = (
 /mob/living/simple_animal/hostile/trog/tunneler,
 /turf/open/indestructible/ground/inside/mountain,
@@ -25575,6 +25704,11 @@
 "dSM" = (
 /turf/closed/wall/f13/store,
 /area/f13/building/firestation)
+"dSW" = (
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "topshadowleft"
+	},
+/area/f13/wasteland/heaven)
 "dTj" = (
 /obj/structure/car/rubbish3,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -25709,6 +25843,17 @@
 	icon_state = "bluedirtychess2"
 	},
 /area/f13/village)
+"dYp" = (
+/obj/structure/car/rubbish1,
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "verticalinnermain0"
+	},
+/area/f13/wasteland/east)
+"dYy" = (
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "topshadowright"
+	},
+/area/f13/wasteland/museum)
 "dYE" = (
 /obj/machinery/light/small/broken{
 	dir = 1
@@ -25965,6 +26110,11 @@
 /obj/item/storage/trash_stack,
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland/quarry)
+"ehQ" = (
+/turf/open/indestructible/ground/outside/desert{
+	icon_state = "wasteland33"
+	},
+/area/f13/wasteland/train)
 "ehU" = (
 /obj/effect/spawner/lootdrop/f13/weapon/melee/random_mid,
 /turf/open/indestructible/ground/outside/dirt,
@@ -26065,13 +26215,15 @@
 "elx" = (
 /turf/open/indestructible/ground/outside/ruins,
 /area/f13/caves)
-"elO" = (
-/obj/machinery/chem_dispenser,
-/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite{
-	icon_state = "showroomfloor";
-	name = "tile"
+"elA" = (
+/obj/structure/barricade/sandbags,
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "verticalinnermain0"
 	},
-/area/f13/building)
+/area/f13/wasteland/massfusion)
+"elO" = (
+/turf/open/floor/plating/dirt,
+/area/f13/caves)
 "elP" = (
 /obj/structure/table/optable,
 /turf/open/floor/f13{
@@ -26525,6 +26677,12 @@
 	icon_state = "darkrusty"
 	},
 /area/f13/brotherhood)
+"ezG" = (
+/obj/item/storage/trash_stack,
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "horizontaltopborderbottom0"
+	},
+/area/f13/wasteland/heaven)
 "ezK" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/filingcabinet,
@@ -26707,6 +26865,18 @@
 	icon_state = "bar"
 	},
 /area/f13/building)
+"eGX" = (
+/obj/machinery/light/small{
+	dir = 1;
+	light_color = "red"
+	},
+/obj/structure/railing{
+	dir = 4
+	},
+/turf/open/floor/plasteel/cult{
+	name = "stage floor"
+	},
+/area/f13/bar/heaven)
 "eGZ" = (
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "horizontalbottomborderbottom2right"
@@ -26719,6 +26889,11 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/white,
 /area/f13/village)
+"eHm" = (
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "verticaloutermain0"
+	},
+/area/f13/wasteland/east)
 "eHx" = (
 /obj/structure/railing{
 	dir = 10
@@ -27080,7 +27255,7 @@
 	},
 /obj/effect/decal/waste,
 /turf/open/indestructible/ground/outside/road{
-	icon_state = "horizontalinnermain0"
+	icon_state = "verticalinnermain0"
 	},
 /area/f13/wasteland/massfusion)
 "eRL" = (
@@ -27118,7 +27293,7 @@
 	name = "Ambulance Bay 2"
 	},
 /turf/open/indestructible/ground/outside/road{
-	icon_state = "verticalleftborderright2top"
+	icon_state = "verticalleftborderright0"
 	},
 /area/f13/building/hospital)
 "eTJ" = (
@@ -27171,7 +27346,7 @@
 /obj/structure/flora/ausbushes/sparsegrass,
 /turf/open/indestructible/ground/outside/dirt{
 	dir = 1;
-	icon_state = "dirt"
+	icon_state = "dirtcorner"
 	},
 /area/f13/wasteland/east)
 "eVh" = (
@@ -27523,7 +27698,7 @@
 	name = "road barrier"
 	},
 /turf/open/indestructible/ground/outside/road{
-	icon_state = "horizontalinnermain0"
+	icon_state = "verticalrightborderleft0"
 	},
 /area/f13/wasteland/massfusion)
 "ffb" = (
@@ -27566,6 +27741,11 @@
 /turf/open/indestructible/ground/outside/sidewalk{
 	dir = 8;
 	icon_state = "outerpavement"
+	},
+/area/f13/wasteland/east)
+"fgL" = (
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "innercornerpieceright"
 	},
 /area/f13/wasteland/east)
 "fgZ" = (
@@ -27765,7 +27945,7 @@
 /area/f13/building/mall)
 "fnd" = (
 /turf/open/indestructible/ground/outside/road{
-	icon_state = "horizontalinnermain2"
+	icon_state = "verticalrightborderleft0"
 	},
 /area/f13/wasteland/train)
 "fnj" = (
@@ -27955,6 +28135,14 @@
 /obj/structure/flora/grass/wasteland,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/caves)
+"ftH" = (
+/obj/effect/decal/marking{
+	icon_state = "doublevertical"
+	},
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "verticalinnermain2"
+	},
+/area/f13/wasteland/east)
 "ftI" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -28267,6 +28455,13 @@
 /obj/machinery/mineral/wasteland_vendor/mining,
 /turf/open/floor/wood/wood_mosaic,
 /area/f13/city/bighorn)
+"fBg" = (
+/obj/structure/fence{
+	dir = 4
+	},
+/obj/structure/barricade/wooden/planks/pregame,
+/turf/open/floor/plating/dirt,
+/area/f13/wasteland/train)
 "fBF" = (
 /obj/effect/turf_decal/weather/dirt{
 	dir = 1
@@ -28352,9 +28547,13 @@
 	},
 /area/f13/wasteland/west)
 "fEW" = (
-/obj/machinery/vending/cola,
-/turf/open/indestructible/ground/outside/sidewalk,
-/area/f13/wasteland/west)
+/obj/effect/decal/marking{
+	icon_state = "doublevertical"
+	},
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "verticalinnermain1"
+	},
+/area/f13/wasteland/train)
 "fFf" = (
 /obj/structure/flora/grass/wasteland{
 	icon_state = "tall_grass_3"
@@ -28552,6 +28751,13 @@
 	},
 /turf/open/indestructible/ground/outside/sidewalk,
 /area/f13/wasteland/bighorn)
+"fKS" = (
+/obj/item/circuitboard/machine/chem_dispenser/drinks,
+/turf/closed/wall/f13/store{
+	desc = "A pre-War wall made of solid concrete.";
+	name = "concrete wall"
+	},
+/area/f13/building)
 "fKY" = (
 /obj/structure/dresser,
 /turf/open/floor/carpet/black,
@@ -28580,7 +28786,7 @@
 	icon_state = "doubleverticalbottom"
 	},
 /turf/open/indestructible/ground/outside/road{
-	icon_state = "horizontalinnermain0"
+	icon_state = "verticalinnermain0"
 	},
 /area/f13/wasteland/train)
 "fLO" = (
@@ -28950,7 +29156,7 @@
 /obj/structure/flora/grass/wasteland{
 	icon_state = "tall_grass_2"
 	},
-/turf/open/indestructible/ground/outside/dirt,
+/turf/open/floor/plating/dirt,
 /area/f13/wasteland/train)
 "fWo" = (
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -29039,11 +29245,14 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
 "fZL" = (
-/obj/machinery/light/sign/heaven{
-	pixel_y = 32
+/obj/machinery/door/poddoor/shutters/old{
+	id = "factorygate";
+	name = "road barrier"
 	},
-/turf/open/indestructible/ground/outside/sidewalk,
-/area/f13/wasteland/heaven)
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "verticalleftborderright0"
+	},
+/area/f13/wasteland/massfusion)
 "gak" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -29188,11 +29397,17 @@
 /turf/open/indestructible/ground/outside/savannah,
 /area/f13/brotherhood/leisure)
 "gft" = (
-/obj/structure/railing{
-	dir = 1
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
 	},
-/obj/structure/chair/sofa/corp,
-/turf/open/floor/carpet/red,
+/obj/structure/railing{
+	layer = 3.3;
+	plane = -3
+	},
+/obj/structure/table/booth,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	name = "metal plating"
+	},
 /area/f13/bar/heaven)
 "gfu" = (
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -29236,6 +29451,14 @@
 /obj/structure/flora/grass/wasteland,
 /turf/open/indestructible/ground/outside/savannah/leftcenter,
 /area/f13/caves)
+"ghv" = (
+/obj/effect/decal/marking{
+	icon_state = "doubleverticalcorroded"
+	},
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "verticalinnermain2"
+	},
+/area/f13/wasteland/east)
 "ghC" = (
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "verticalinnermain1"
@@ -29251,7 +29474,8 @@
 	},
 /area/f13/building/firestation)
 "ghI" = (
-/obj/structure/chair/sofa/corp{
+/obj/machinery/light/floor,
+/obj/structure/chair/sofa/corner{
 	dir = 8
 	},
 /turf/open/floor/carpet/red,
@@ -29463,6 +29687,14 @@
 	icon_state = "horizontalbottombordertop2"
 	},
 /area/f13/wasteland/firestation)
+"gqr" = (
+/obj/item/cigbutt/cigarbutt{
+	pixel_x = -4;
+	pixel_y = -2
+	},
+/obj/structure/table/wood/settler,
+/turf/open/floor/carpet/red,
+/area/f13/bar/heaven)
 "gqs" = (
 /obj/structure/tires/five,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -30273,6 +30505,15 @@
 	destination_z = 9
 	},
 /area/f13/tunnel/southeast)
+"gPD" = (
+/obj/structure/frame/machine,
+/obj/item/stack/cable_coil/random/five,
+/obj/item/circuitboard/machine/chem_dispenser,
+/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite{
+	icon_state = "showroomfloor";
+	name = "tile"
+	},
+/area/f13/building)
 "gQf" = (
 /obj/machinery/computer/shuttle/bos{
 	dir = 8;
@@ -30948,11 +31189,11 @@
 	},
 /area/f13/building/museum)
 "hlD" = (
-/obj/structure/car/rubbish2,
+/obj/structure/car/rubbish1,
 /turf/open/indestructible/ground/outside/road{
-	icon_state = "horizontalinnermain0"
+	icon_state = "horizontaltopborderbottom0"
 	},
-/area/f13/wasteland/west)
+/area/f13/wasteland/east)
 "hlS" = (
 /obj/structure/fence/corner{
 	dir = 4
@@ -31482,7 +31723,7 @@
 	icon_state = "dottedvertical"
 	},
 /turf/open/indestructible/ground/outside/road{
-	icon_state = "horizontalinnermain0"
+	icon_state = "verticalinnermain0"
 	},
 /area/f13/wasteland/train)
 "hGv" = (
@@ -31590,17 +31831,24 @@
 /turf/open/floor/carpet,
 /area/f13/building/mall)
 "hKY" = (
-/obj/structure/fence/corner{
-	dir = 5
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "verticalleftborderright0"
 	},
-/turf/open/indestructible/ground/outside/sidewalk,
-/area/f13/wasteland/heaven)
+/area/f13/tunnel/northeast)
 "hLL" = (
 /turf/open/indestructible/ground/outside/ruins{
 	dir = 8;
 	icon_state = "rubblecorner"
 	},
 /area/f13/wasteland/museum)
+"hMa" = (
+/obj/effect/decal/marking{
+	icon_state = "dottedverticalcorroded"
+	},
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "verticalinnermain1"
+	},
+/area/f13/wasteland/train)
 "hMj" = (
 /obj/item/trash/popcorn,
 /turf/open/floor/f13/wood,
@@ -31946,6 +32194,14 @@
 	icon_state = "reddirtyfull"
 	},
 /area/f13/building/museum)
+"hWj" = (
+/obj/effect/decal/cleanable/glass,
+/obj/machinery/chem_heater,
+/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite{
+	icon_state = "showroomfloor";
+	name = "tile"
+	},
+/area/f13/building)
 "hWp" = (
 /turf/open/indestructible/ground/outside/sidewalk{
 	dir = 1;
@@ -32784,7 +33040,7 @@
 	icon_state = "doubleverticalcorroded"
 	},
 /turf/open/indestructible/ground/outside/road{
-	icon_state = "horizontalinnermain0"
+	icon_state = "verticalinnermain0"
 	},
 /area/f13/wasteland/train)
 "ixm" = (
@@ -32833,6 +33089,14 @@
 	icon_state = "dirt"
 	},
 /area/f13/building)
+"iyd" = (
+/obj/effect/decal/marking{
+	icon_state = "dottedverticaldegraded"
+	},
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "verticalinnermain1"
+	},
+/area/f13/wasteland/east)
 "izc" = (
 /turf/open/indestructible/ground/outside/desert{
 	icon_state = "wasteland33"
@@ -33125,9 +33389,6 @@
 	},
 /area/f13/wasteland/west)
 "iHD" = (
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
-	},
 /obj/effect/decal/remains/human,
 /obj/item/reagent_containers/pill/patch/jet,
 /obj/effect/decal/cleanable/blood/old,
@@ -33150,6 +33411,14 @@
 /obj/effect/decal/cleanable/oil,
 /turf/open/floor/f13/wood,
 /area/f13/building)
+"iIb" = (
+/obj/structure/railing{
+	dir = 4
+	},
+/turf/open/floor/plasteel/cult{
+	name = "stage floor"
+	},
+/area/f13/bar/heaven)
 "iIm" = (
 /obj/structure/table,
 /obj/item/storage/part_replacer,
@@ -33394,12 +33663,11 @@
 /turf/open/floor/plasteel/f13/vault_floor/white,
 /area/f13/building/mall)
 "iNZ" = (
-/obj/structure/railing{
-	dir = 1
+/obj/effect/landmark/start/f13/wastelander,
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "horizontaltopborderbottom0"
 	},
-/obj/structure/chair/sofa/corp/left,
-/turf/open/floor/carpet/red,
-/area/f13/bar/heaven)
+/area/f13/tunnel/southeast)
 "iOg" = (
 /turf/open/indestructible/ground/outside/ruins{
 	icon_state = "rubblepillar"
@@ -33590,6 +33858,12 @@
 	icon_state = "verticalleftborderleft3"
 	},
 /area/f13/wasteland/hospital)
+"iTb" = (
+/turf/open/indestructible/ground/outside/ruins{
+	dir = 1;
+	icon_state = "rubblecorner"
+	},
+/area/f13/wasteland/nanotrasen)
 "iTd" = (
 /obj/structure/flora/grass/wasteland{
 	icon_state = "tall_grass_3"
@@ -34042,7 +34316,7 @@
 	icon_state = "doubleverticaldegraded"
 	},
 /turf/open/indestructible/ground/outside/road{
-	icon_state = "horizontalinnermain0"
+	icon_state = "verticalinnermain0"
 	},
 /area/f13/wasteland/train)
 "jdU" = (
@@ -34229,6 +34503,12 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/freezer,
 /area/f13/brotherhood)
+"jiT" = (
+/obj/machinery/vending/coffee,
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "horizontaloutermain2"
+	},
+/area/f13/wasteland/heaven)
 "jiX" = (
 /obj/effect/decal/riverbank,
 /obj/structure/fence/wooden{
@@ -34396,18 +34676,14 @@
 /turf/open/floor/f13,
 /area/f13/building)
 "jmf" = (
-/obj/item/shard,
-/obj/effect/decal/cleanable/glass,
-/obj/machinery/chem_heater,
-/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite{
-	icon_state = "showroomfloor";
-	name = "tile"
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "verticalleftborderright1"
 	},
-/area/f13/building)
+/area/f13/wasteland/train)
 "jmh" = (
 /obj/structure/car/rubbish3,
 /turf/open/indestructible/ground/outside/road{
-	icon_state = "horizontalinnermain0"
+	icon_state = "verticalinnermain0"
 	},
 /area/f13/wasteland/train)
 "jmn" = (
@@ -34971,6 +35247,11 @@
 /obj/effect/spawner/lootdrop/f13/junkspawners,
 /turf/open/floor/plasteel/f13/vault_floor/dark,
 /area/f13/building/mall)
+"jHR" = (
+/obj/machinery/light/floor,
+/obj/structure/chair/sofa/corner,
+/turf/open/floor/carpet/red,
+/area/f13/bar/heaven)
 "jIk" = (
 /turf/open/indestructible/ground/outside/sidewalk{
 	dir = 1;
@@ -35698,7 +35979,7 @@
 "kku" = (
 /obj/effect/turf_decal/stripes/asteroid/line,
 /turf/open/indestructible/ground/outside/road{
-	icon_state = "horizontalinnermain0"
+	icon_state = "verticalinnermain0"
 	},
 /area/f13/wasteland/massfusion)
 "kkw" = (
@@ -36229,6 +36510,14 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/red/white/side,
 /area/f13/building/mall)
+"kCa" = (
+/obj/effect/decal/marking{
+	icon_state = "doublevertical"
+	},
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "verticalinnermain2"
+	},
+/area/f13/wasteland/train)
 "kCd" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_y = 28
@@ -36527,6 +36816,12 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vault1,
 /area/f13/building/museum)
+"kJM" = (
+/obj/effect/turf_decal/weather/dirt{
+	dir = 10
+	},
+/turf/open/indestructible/ground/outside/water,
+/area/f13/wasteland/train)
 "kJO" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -36696,6 +36991,14 @@
 	icon_state = "horizontaltopborderbottom2right"
 	},
 /area/f13/wasteland/bighorn)
+"kPX" = (
+/obj/effect/decal/marking{
+	icon_state = "doubleverticaltop"
+	},
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "verticalinnermain2"
+	},
+/area/f13/wasteland/east)
 "kQj" = (
 /obj/structure/railing{
 	dir = 1
@@ -36975,19 +37278,13 @@
 /turf/open/floor/plasteel/f13/vault_floor/white,
 /area/f13/building/hospital)
 "kXR" = (
-/obj/structure/sign/poster/prewar/poster74{
-	pixel_y = 32
+/obj/structure/table_frame,
+/obj/effect/decal/cleanable/glass,
+/obj/item/shard,
+/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite{
+	icon_state = "showroomfloor";
+	name = "tile"
 	},
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/machinery/vending/medical{
-	pixel_x = -3
-	},
-/obj/effect/decal/cleanable/dirt{
-	color = "000000"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite/rarecyan,
 /area/f13/building)
 "kXT" = (
 /obj/item/flashlight/lantern,
@@ -37244,6 +37541,11 @@
 	icon_state = "verticalinnermain2top"
 	},
 /area/f13/wasteland/west)
+"lgq" = (
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "verticalrightborderleft1"
+	},
+/area/f13/wasteland/train)
 "lgD" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/small{
@@ -37373,6 +37675,10 @@
 /obj/structure/flora/junglebush/b,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland/valley)
+"ljj" = (
+/obj/machinery/jukebox,
+/turf/open/floor/carpet/red,
+/area/f13/bar/heaven)
 "ljp" = (
 /obj/structure/barricade/wooden/strong,
 /turf/open/indestructible/ground/outside/desert,
@@ -37395,6 +37701,11 @@
 	icon_state = "darkrusty"
 	},
 /area/f13/building/museum)
+"lki" = (
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "topshadowright"
+	},
+/area/f13/wasteland/heaven)
 "lkm" = (
 /obj/structure/campfire/barrel,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -37735,11 +38046,14 @@
 	},
 /area/f13/wasteland/west)
 "lvq" = (
-/obj/structure/chair/greyscale{
-	dir = 1
+/obj/structure/camera_assembly{
+	dir = 8
 	},
 /obj/effect/decal/cleanable/dirt{
 	color = "000000"
+	},
+/obj/structure/chair/f13chair1{
+	dir = 1
 	},
 /turf/open/floor/f13/wood,
 /area/f13/building)
@@ -37768,6 +38082,15 @@
 	icon_state = "white"
 	},
 /area/f13/brotherhood)
+"lwR" = (
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
+/obj/structure/chair/f13chair1{
+	dir = 1
+	},
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "lwS" = (
 /obj/structure/flora/tree/tall{
 	icon_state = "tree_3"
@@ -38017,6 +38340,13 @@
 	},
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland/valley)
+"lEf" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/observer_start,
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "horizontalinnermain1"
+	},
+/area/f13/wasteland/bighorn)
 "lEr" = (
 /obj/structure/car/rubbish1,
 /turf/open/indestructible/ground/outside/road{
@@ -38089,11 +38419,11 @@
 	},
 /area/f13/brotherhood)
 "lGu" = (
-/obj/item/ammo_casing/c10mm,
-/turf/open/indestructible/ground/outside/road{
-	icon_state = "horizontalinnermain0"
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
 	},
-/area/f13/wasteland/west)
+/turf/open/floor/wood,
+/area/f13/bar/heaven)
 "lGE" = (
 /mob/living/simple_animal/hostile/radroach,
 /turf/open/floor/f13/wood,
@@ -38483,12 +38813,10 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "lQs" = (
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "verticalleftborderright0"
 	},
-/obj/machinery/vending/cigarette,
-/turf/open/floor/wood/wood_mosaic/wood_mosaic_dark,
-/area/f13/bar/heaven)
+/area/f13/wasteland/train)
 "lQv" = (
 /obj/effect/decal/remains{
 	icon_state = "remains"
@@ -38534,8 +38862,7 @@
 "lRq" = (
 /obj/effect/spawner/lootdrop/f13/junkspawners,
 /turf/open/indestructible/ground/outside/road{
-	dir = 8;
-	icon_state = "horizontalinnermain2left"
+	icon_state = "verticalinnermain0"
 	},
 /area/f13/wasteland/east)
 "lRC" = (
@@ -38654,7 +38981,7 @@
 	icon_state = "goo8"
 	},
 /turf/open/indestructible/ground/outside/road{
-	icon_state = "horizontalinnermain2"
+	icon_state = "verticalrightborderleft1"
 	},
 /area/f13/wasteland/east)
 "lUn" = (
@@ -38830,6 +39157,14 @@
 /obj/item/instrument/guitar,
 /turf/open/floor/wood/wood_mosaic,
 /area/f13/building/mall)
+"lZY" = (
+/obj/effect/decal/marking{
+	icon_state = "doubleverticalbottom"
+	},
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "verticalinnermain2"
+	},
+/area/f13/wasteland/east)
 "mai" = (
 /obj/effect/turf_decal/box/white,
 /obj/effect/decal/cleanable/dirt{
@@ -38854,9 +39189,10 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "mbs" = (
-/obj/machinery/vending/coffee,
-/turf/open/indestructible/ground/outside/sidewalk,
-/area/f13/wasteland/heaven)
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "horizontalbottombordertop0"
+	},
+/area/f13/wasteland/museum)
 "mbv" = (
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "horizontalbottombordertop0"
@@ -38966,12 +39302,10 @@
 	},
 /area/f13/wasteland/bighorn)
 "mdh" = (
-/obj/structure/fence,
-/turf/open/indestructible/ground/outside/dirt{
-	dir = 8;
-	icon_state = "dirt"
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "verticalinnermain1"
 	},
-/area/f13/wasteland/train)
+/area/f13/tunnel/northeast)
 "mdP" = (
 /obj/item/clothing/accessory/medal/plasma/nobel_science{
 	name = "Medal of Science"
@@ -38979,6 +39313,17 @@
 /obj/structure/displaycase,
 /turf/open/floor/f13/wood,
 /area/f13/building/museum)
+"mea" = (
+/obj/structure/rack,
+/obj/item/cane,
+/obj/item/cane,
+/obj/item/cane,
+/obj/item/cane,
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/neutral/neutralsolid,
+/area/f13/building)
 "meb" = (
 /obj/item/storage/trash_stack,
 /turf/open/indestructible/ground/outside/sidewalk,
@@ -39038,7 +39383,7 @@
 	pixel_x = 32
 	},
 /turf/open/indestructible/ground/outside/road{
-	icon_state = "horizontalinnermain0"
+	icon_state = "verticalrightborderleft0"
 	},
 /area/f13/tunnel/northeast)
 "mfn" = (
@@ -39074,6 +39419,12 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/f13/brotherhood)
+"mfX" = (
+/obj/effect/spawner/lootdrop/f13/junkspawners,
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "verticalrightborderleft0"
+	},
+/area/f13/wasteland/east)
 "mgd" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -39349,13 +39700,10 @@
 	},
 /area/f13/wasteland/hospital)
 "moJ" = (
-/obj/structure/table_frame,
-/obj/effect/decal/cleanable/glass,
-/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite{
-	icon_state = "showroomfloor";
-	name = "tile"
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "verticalinnermain2"
 	},
-/area/f13/building)
+/area/f13/wasteland/train)
 "moV" = (
 /obj/structure/table/wood/settler,
 /obj/item/kitchen/knife,
@@ -39419,6 +39767,20 @@
 	icon_state = "floorrustysolid"
 	},
 /area/f13/building/mall)
+"mqr" = (
+/obj/effect/decal/marking{
+	icon_state = "doubleverticaltop"
+	},
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "verticalinnermain1"
+	},
+/area/f13/wasteland/train)
+"mqx" = (
+/obj/effect/decal/waste,
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "verticalrightborderleft0"
+	},
+/area/f13/wasteland/massfusion)
 "mqy" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -39538,6 +39900,14 @@
 	},
 /turf/open/indestructible/ground/outside/water,
 /area/f13/wasteland/east)
+"mvQ" = (
+/obj/structure/table/wood/settler,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/item/restraints/handcuffs/fake/kinky,
+/turf/open/floor/carpet/red,
+/area/f13/bar/heaven)
 "mvS" = (
 /obj/machinery/door/poddoor/shutters/preopen{
 	id = "bargambling"
@@ -39688,16 +40058,13 @@
 /turf/open/floor/holofloor/carpet,
 /area/f13/city/bighorn)
 "mzW" = (
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
-	},
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
+/obj/effect/decal/marking{
+	icon_state = "doubleverticalcorroded"
 	},
 /turf/open/indestructible/ground/outside/road{
-	icon_state = "verticalinnermain0"
+	icon_state = "verticalinnermain1"
 	},
-/area/f13/wasteland/east)
+/area/f13/wasteland/train)
 "mAf" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -39815,8 +40182,17 @@
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
 	},
-/obj/structure/wreck/trash/three_barrels,
-/turf/open/floor/wood/wood_mosaic/wood_mosaic_dark,
+/obj/structure/railing{
+	layer = 3.3;
+	plane = -3;
+	dir = 6
+	},
+/obj/structure/chair/booth{
+	dir = 8
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	name = "metal plating"
+	},
 /area/f13/bar/heaven)
 "mEH" = (
 /obj/effect/decal/cleanable/dirt{
@@ -39959,6 +40335,12 @@
 /obj/machinery/light/small,
 /obj/machinery/workbench,
 /turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
+"mHP" = (
+/obj/effect/turf_decal/weather/dirt{
+	dir = 5
+	},
+/turf/open/indestructible/ground/outside/water,
 /area/f13/caves)
 "mHZ" = (
 /turf/open/floor/f13/wood,
@@ -40132,6 +40514,13 @@
 	icon_state = "verticalleftborderleft2"
 	},
 /area/f13/building/hospital)
+"mOP" = (
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
+/obj/machinery/autolathe/ammo/unlocked_basic,
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "mOV" = (
 /obj/effect/decal/cleanable/generic,
 /obj/effect/decal/cleanable/dirt,
@@ -40193,11 +40582,20 @@
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland/valley)
 "mQk" = (
-/obj/structure/railing{
-	dir = 1
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
 	},
-/obj/structure/chair/sofa/corp/right,
-/turf/open/floor/carpet/red,
+/obj/structure/railing{
+	layer = 3.3;
+	plane = -3;
+	dir = 10
+	},
+/obj/structure/chair/booth{
+	dir = 4
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	name = "metal plating"
+	},
 /area/f13/bar/heaven)
 "mQN" = (
 /obj/structure/fence/wooden{
@@ -40268,8 +40666,7 @@
 	},
 /area/f13/wasteland/hospital)
 "mSq" = (
-/obj/structure/table/reinforced,
-/obj/item/storage/pill_bottle/lsd,
+/obj/structure/chair/sofa,
 /turf/open/floor/carpet/red,
 /area/f13/bar/heaven)
 "mSr" = (
@@ -40296,14 +40693,11 @@
 /turf/open/floor/f13/wood,
 /area/f13/village)
 "mTD" = (
-/obj/effect/decal/marking{
-	icon_state = "doubleverticaltop"
-	},
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/stripes/asteroid/line,
 /turf/open/indestructible/ground/outside/road{
-	icon_state = "horizontaltopborderbottom0"
+	icon_state = "verticalleftborderright0"
 	},
-/area/f13/wasteland/east)
+/area/f13/wasteland/massfusion)
 "mTI" = (
 /obj/structure/bonfire/prelit,
 /turf/open/indestructible/ground/outside/dirt,
@@ -40444,6 +40838,12 @@
 /mob/living/simple_animal/hostile/mirelurk/baby,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland/east)
+"mYd" = (
+/obj/structure/chair/sofa/right{
+	dir = 1
+	},
+/turf/open/floor/carpet/red,
+/area/f13/bar/heaven)
 "mYw" = (
 /obj/structure/closet/crate/trashcart,
 /obj/effect/spawner/lootdrop/f13/weapon/melee/tier1,
@@ -40485,6 +40885,14 @@
 	icon_state = "verticalinnermain0"
 	},
 /area/f13/wasteland/east)
+"mZR" = (
+/obj/structure/obstacle/barbedwire{
+	dir = 4
+	},
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "verticalinnermain0"
+	},
+/area/f13/wasteland/massfusion)
 "nai" = (
 /obj/structure/table/wood,
 /obj/effect/spawner/lootdrop/f13/crafting,
@@ -40642,14 +41050,15 @@
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland/valley)
 "nfu" = (
-/obj/structure/flora/grass/wasteland{
-	icon_state = "tall_grass_6";
-	pixel_x = -11;
-	pixel_y = 11
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "verticalinnermain1"
 	},
-/obj/structure/flora/tree/wasteland,
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland/east)
+/area/f13/wasteland/train)
+"nfS" = (
+/obj/structure/sink/deep_water,
+/obj/effect/turf_decal/weather/dirt,
+/turf/open/indestructible/ground/outside/water,
+/area/f13/caves)
 "ngi" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13{
@@ -40721,6 +41130,12 @@
 	icon_state = "horizontalbottomborderbottom2"
 	},
 /area/f13/wasteland/east)
+"njC" = (
+/obj/structure/barricade/wooden,
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "verticalrightborderleft0"
+	},
+/area/f13/building/hospital)
 "njD" = (
 /obj/structure/fence,
 /obj/structure/fence/corner{
@@ -40765,7 +41180,6 @@
 "nlI" = (
 /obj/structure/simple_door/room,
 /obj/structure/barricade/wooden/planks/pregame,
-/obj/item/mine/shrapnel,
 /turf/open/floor/f13{
 	icon_state = "bar"
 	},
@@ -40863,12 +41277,14 @@
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland/museum)
 "nnF" = (
-/obj/structure/table/reinforced,
-/obj/item/cigbutt/cigarbutt{
-	pixel_x = -4;
-	pixel_y = -2
+/obj/machinery/light/floor,
+/obj/structure/railing{
+	dir = 6;
+	layer = 3.5
 	},
-/turf/open/floor/carpet/red,
+/turf/open/floor/plasteel/cult{
+	name = "stage floor"
+	},
 /area/f13/bar/heaven)
 "noo" = (
 /obj/structure/rack,
@@ -41038,6 +41454,13 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/freezer,
 /area/f13/brotherhood)
+"ntr" = (
+/obj/structure/curtain{
+	color = "#5c131b";
+	pixel_y = -32
+	},
+/turf/open/floor/carpet/red,
+/area/f13/bar/heaven)
 "ntu" = (
 /obj/structure/obstacle/barbedwire{
 	dir = 1
@@ -41267,18 +41690,10 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "nzi" = (
-/obj/structure/rack,
-/obj/item/cane,
-/obj/item/cane,
-/obj/item/cane,
-/obj/item/cane,
-/obj/effect/decal/cleanable/dirt{
-	color = "000000"
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "verticalrightborderleft1"
 	},
-/obj/item/reagent_containers/hypospray/medipen/stimpak,
-/obj/item/reagent_containers/hypospray/medipen/stimpak,
-/turf/open/floor/plasteel/f13/vault_floor/neutral/neutralsolid,
-/area/f13/building)
+/area/f13/tunnel/northeast)
 "nzp" = (
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "horizontalbottomborderbottom0"
@@ -41365,6 +41780,11 @@
 	},
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland/hospital)
+"nCu" = (
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "verylittleshadowleft"
+	},
+/area/f13/wasteland/heaven)
 "nCD" = (
 /turf/open/indestructible/ground/outside/savannah/bottomcenter,
 /area/f13/caves)
@@ -41465,10 +41885,7 @@
 /area/f13/followers)
 "nGe" = (
 /obj/structure/fence/corner,
-/turf/open/indestructible/ground/outside/dirt{
-	dir = 1;
-	icon_state = "dirtcorner"
-	},
+/turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland/train)
 "nGs" = (
 /obj/effect/decal/cleanable/dirt,
@@ -41595,6 +42012,9 @@
 /turf/open/floor/plasteel/f13/vault_floor/white,
 /area/f13/building/mall)
 "nLc" = (
+/obj/structure/lamp_post/doubles{
+	dir = 4
+	},
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "outerborder"
 	},
@@ -41716,6 +42136,12 @@
 	icon_state = "white"
 	},
 /area/f13/brotherhood/leisure)
+"nQs" = (
+/obj/effect/turf_decal/stripes/asteroid/line,
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "verticalrightborderleft0"
+	},
+/area/f13/wasteland/massfusion)
 "nQt" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -41888,6 +42314,12 @@
 	icon_state = "dirtcorner"
 	},
 /area/f13/wasteland/east)
+"nTX" = (
+/obj/structure/fence/corner{
+	dir = 4
+	},
+/turf/open/indestructible/ground/outside/sidewalk,
+/area/f13/wasteland/heaven)
 "nTY" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/rack,
@@ -41956,6 +42388,12 @@
 	icon_state = "rampdowntop"
 	},
 /area/f13/city/bighorn)
+"nWK" = (
+/obj/effect/turf_decal/weather/dirt{
+	dir = 6
+	},
+/turf/open/indestructible/ground/outside/water,
+/area/f13/wasteland/train)
 "nWT" = (
 /turf/open/indestructible/ground/outside/road{
 	dir = 8;
@@ -42227,6 +42665,11 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/village)
+"ofD" = (
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "verticalleftborderright1"
+	},
+/area/f13/wasteland/heaven)
 "ofG" = (
 /obj/effect/turf_decal/weather/dirt{
 	dir = 8
@@ -42712,6 +43155,12 @@
 	icon_state = "innershade"
 	},
 /area/f13/wasteland/west)
+"otr" = (
+/obj/effect/spawner/lootdrop/f13/junkspawners,
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "verticalinnermain1"
+	},
+/area/f13/wasteland/east)
 "otA" = (
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "verticalrightborderright1"
@@ -43051,7 +43500,7 @@
 /obj/structure/barricade/wooden,
 /obj/structure/barricade/wooden/planks/pregame,
 /turf/open/indestructible/ground/outside/road{
-	icon_state = "verticalrightborderleft1"
+	icon_state = "verticalrightborderleft0"
 	},
 /area/f13/wasteland/hospital)
 "oFD" = (
@@ -43484,6 +43933,15 @@
 	},
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland/bighorn)
+"oPW" = (
+/obj/structure/bed/mattress{
+	icon_state = "mattress2";
+	pixel_y = 7
+	},
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "verticalinnermain0"
+	},
+/area/f13/wasteland/east)
 "oPX" = (
 /obj/structure/chair/wood{
 	dir = 4
@@ -43595,6 +44053,11 @@
 "oUj" = (
 /turf/open/floor/f13/wood,
 /area/f13/village)
+"oUk" = (
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "horizontaltopborderbottomleft"
+	},
+/area/f13/wasteland/east)
 "oUo" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/hobo,
@@ -43693,6 +44156,10 @@
 	},
 /turf/open/floor/wood/wood_common,
 /area/f13/followers)
+"oYn" = (
+/obj/structure/chair/sofa/right,
+/turf/open/floor/carpet/red,
+/area/f13/bar/heaven)
 "oYu" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
@@ -43762,7 +44229,7 @@
 	dir = 4
 	},
 /turf/open/indestructible/ground/outside/road{
-	icon_state = "horizontalinnermain0"
+	icon_state = "verticalrightborderleft0"
 	},
 /area/f13/wasteland/massfusion)
 "oZA" = (
@@ -44345,10 +44812,16 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plasteel/f13/vault_floor/white,
 /area/f13/building/mall)
+"ptm" = (
+/obj/effect/landmark/start/f13/outsider,
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "horizontaltopborderbottom0"
+	},
+/area/f13/tunnel/southeast)
 "ptn" = (
 /obj/item/ammo_casing/c10mm,
 /turf/open/indestructible/ground/outside/road{
-	icon_state = "horizontalinnermain0"
+	icon_state = "verticalrightborderleft0"
 	},
 /area/f13/wasteland/train)
 "pto" = (
@@ -45286,6 +45759,20 @@
 	},
 /turf/open/floor/wood/wood_common,
 /area/f13/followers)
+"pYf" = (
+/obj/structure/sign/poster/prewar/poster74{
+	pixel_y = 32
+	},
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
+/obj/structure/rack,
+/obj/effect/spawner/lootdrop/f13/medical/wasteland/meds,
+/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite/rarecyan,
+/area/f13/building)
 "pYi" = (
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "horizontalinnermain2"
@@ -45416,7 +45903,9 @@
 	dir = 4
 	},
 /obj/effect/decal/cleanable/oil/slippery,
-/turf/open/indestructible/ground/outside/sidewalk,
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "horizontaloutermain0"
+	},
 /area/f13/wasteland/west)
 "qdz" = (
 /obj/machinery/autolathe,
@@ -45493,14 +45982,10 @@
 	},
 /area/f13/wasteland/museum)
 "qgl" = (
-/obj/structure/nest/protectron{
-	layer = 3;
-	max_mobs = 1;
-	name = "towel boy pod";
-	pixel_y = 20
+/turf/open/indestructible/ground/outside/desert{
+	icon_state = "wasteland32"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/blue,
-/area/f13/village)
+/area/f13/wasteland/museum)
 "qgB" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -45852,7 +46337,10 @@
 	dir = 4
 	},
 /obj/structure/barricade/wooden/planks/pregame,
-/turf/open/indestructible/ground/outside/dirt,
+/obj/effect/overlay/desert/sonora/edge{
+	dir = 1
+	},
+/turf/open/floor/plating/dirt,
 /area/f13/wasteland/train)
 "qpA" = (
 /obj/effect/decal/cleanable/dirt,
@@ -45986,7 +46474,7 @@
 "qsM" = (
 /obj/effect/spawner/lootdrop/f13/junkspawners,
 /turf/open/indestructible/ground/outside/road{
-	icon_state = "horizontalinnermain0"
+	icon_state = "verticalinnermain0"
 	},
 /area/f13/wasteland/train)
 "qsS" = (
@@ -46072,13 +46560,12 @@
 	},
 /area/f13/building)
 "quQ" = (
-/obj/effect/decal/cleanable/dirt{
-	color = "#363636"
+/obj/structure/window/fulltile/ruins,
+/obj/structure/barricade/bars{
+	layer = 3.21
 	},
-/turf/open/indestructible/ground/outside/road{
-	icon_state = "topshadowleft"
-	},
-/area/f13/wasteland/east)
+/turf/open/floor/f13/wood,
+/area/f13/bar/heaven)
 "qvG" = (
 /obj/structure/tires,
 /turf/open/indestructible/ground/outside/road{
@@ -46436,7 +46923,7 @@
 /turf/open/indestructible/ground/outside/ruins,
 /area/f13/building/mall)
 "qKg" = (
-/turf/open/indestructible/ground/outside/dirt,
+/turf/open/floor/plating/dirt,
 /area/f13/wasteland/train)
 "qKk" = (
 /obj/structure/table/reinforced,
@@ -46688,6 +47175,14 @@
 	icon_state = "horizontaltopbordertop0"
 	},
 /area/f13/wasteland/nanotrasen)
+"qQl" = (
+/obj/effect/decal/marking{
+	icon_state = "doublevertical"
+	},
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "verticalinnermain1"
+	},
+/area/f13/tunnel/northeast)
 "qQq" = (
 /obj/machinery/light{
 	dir = 4
@@ -47168,7 +47663,7 @@
 	},
 /area/f13/building/massfusion)
 "rfd" = (
-/obj/structure/chair/sofa/corp/left{
+/obj/structure/chair/sofa/left{
 	dir = 8
 	},
 /turf/open/floor/carpet/red,
@@ -47245,7 +47740,7 @@
 	},
 /obj/structure/reagent_dispensers/barrel/dangerous,
 /turf/open/indestructible/ground/outside/road{
-	icon_state = "horizontalinnermain0"
+	icon_state = "verticalrightborderleft0"
 	},
 /area/f13/wasteland/massfusion)
 "riq" = (
@@ -47583,6 +48078,10 @@
 /obj/structure/chair/wood,
 /turf/open/floor/wood/wood_fancy,
 /area/f13/brotherhood/leisure)
+"rrf" = (
+/obj/structure/closet/crate/bin/trashbin,
+/turf/open/floor/carpet/red,
+/area/f13/bar/heaven)
 "rrA" = (
 /obj/structure/chair/stool{
 	dir = 1;
@@ -47648,7 +48147,7 @@
 "rsE" = (
 /obj/effect/decal/waste,
 /turf/open/indestructible/ground/outside/road{
-	icon_state = "horizontalinnermain0"
+	icon_state = "verticalleftborderright0"
 	},
 /area/f13/wasteland/massfusion)
 "rsG" = (
@@ -47926,6 +48425,14 @@
 	icon_state = "rubblepillar"
 	},
 /area/f13/caves)
+"rDf" = (
+/obj/effect/decal/marking{
+	icon_state = "doublehorizontalright"
+	},
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "verticalrightborderleft0"
+	},
+/area/f13/wasteland/massfusion)
 "rDk" = (
 /obj/effect/turf_decal/weather/dirt{
 	dir = 9
@@ -48006,6 +48513,12 @@
 	icon_state = "bar"
 	},
 /area/f13/building)
+"rFG" = (
+/obj/structure/barricade/wooden,
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "horizontalinnermain0"
+	},
+/area/f13/wasteland/east)
 "rGi" = (
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "horizontalinnermain1"
@@ -48038,7 +48551,7 @@
 /area/f13/wasteland/east)
 "rHm" = (
 /turf/open/indestructible/ground/outside/road{
-	icon_state = "horizontalinnermain0"
+	icon_state = "verticalinnermain0"
 	},
 /area/f13/wasteland/train)
 "rHq" = (
@@ -48313,6 +48826,14 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/city/bighorn)
+"rQg" = (
+/obj/structure/obstacle/barbedwire{
+	dir = 4
+	},
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "verticalleftborderright0"
+	},
+/area/f13/wasteland/massfusion)
 "rQu" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13{
@@ -48604,6 +49125,12 @@
 /obj/structure/legion_extractor,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/building)
+"rWs" = (
+/obj/effect/spawner/lootdrop/f13/junkspawners,
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "verticalinnermain1"
+	},
+/area/f13/wasteland/train)
 "rWA" = (
 /obj/structure/flora/tree/tall,
 /turf/open/indestructible/ground/outside/desert,
@@ -48708,7 +49235,7 @@
 	icon_state = "doublevertical"
 	},
 /turf/open/indestructible/ground/outside/road{
-	icon_state = "horizontalinnermain0"
+	icon_state = "verticalinnermain0"
 	},
 /area/f13/wasteland/train)
 "rYm" = (
@@ -49466,7 +49993,6 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/stripes/red/corner,
-/obj/structure/timeddoor/sixtyminute,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/wasteland/museum)
 "sAG" = (
@@ -49572,17 +50098,14 @@
 	icon_state = "doubleverticaltop"
 	},
 /turf/open/indestructible/ground/outside/road{
-	icon_state = "horizontalinnermain0"
+	icon_state = "verticalinnermain0"
 	},
 /area/f13/wasteland/train)
 "sCz" = (
-/obj/effect/decal/marking{
-	icon_state = "doublevertical"
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "verticalrightborderleft0"
 	},
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "horizontaltopbordertop1"
-	},
-/area/f13/wasteland/east)
+/area/f13/building/hospital)
 "sCC" = (
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "outermaincornerinner"
@@ -50223,11 +50746,24 @@
 	icon_state = "darkredfull"
 	},
 /area/f13/city/bighorn)
+"sYk" = (
+/obj/effect/turf_decal/stripes/asteroid/line{
+	dir = 1
+	},
+/obj/effect/decal/waste,
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "verticalleftborderright0"
+	},
+/area/f13/wasteland/massfusion)
 "sYn" = (
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "verticalrightborderright0"
 	},
 /area/f13/wasteland/hospital)
+"sYy" = (
+/obj/machinery/light/sign/chiken_ranch,
+/turf/open/indestructible/ground/outside/sidewalk,
+/area/f13/wasteland/heaven)
 "sYC" = (
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "innermaincornerouter"
@@ -50336,7 +50872,9 @@
 /turf/open/floor/f13/wood,
 /area/f13/caves)
 "tbu" = (
-/obj/item/flag/khan,
+/obj/structure/fence/corner{
+	dir = 1
+	},
 /turf/open/indestructible/ground/outside/sidewalk,
 /area/f13/wasteland/heaven)
 "tbC" = (
@@ -50345,7 +50883,7 @@
 	pixel_y = 32
 	},
 /turf/open/indestructible/ground/outside/road{
-	icon_state = "horizontalinnermain0"
+	icon_state = "verticalinnermain0"
 	},
 /area/f13/wasteland/train)
 "tbM" = (
@@ -51392,9 +51930,25 @@
 /obj/machinery/light,
 /turf/open/floor/plasteel/f13/vault_floor/blue/side,
 /area/f13/building/hospital)
+"tEP" = (
+/obj/effect/decal/marking{
+	icon_state = "doubleverticalcorroded"
+	},
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "horizontalinnermain3"
+	},
+/area/f13/wasteland/east)
 "tFm" = (
 /turf/open/floor/plasteel/f13/vault_floor/white,
 /area/f13/building/hospital)
+"tGc" = (
+/obj/effect/decal/marking{
+	icon_state = "dottedverticalcorroded"
+	},
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "verticalinnermain1"
+	},
+/area/f13/wasteland/east)
 "tGe" = (
 /obj/structure/closet/crate/bin/trashbin,
 /turf/open/floor/wood/wood_wide,
@@ -51437,6 +51991,14 @@
 	},
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland/valley)
+"tGL" = (
+/obj/effect/decal/marking{
+	icon_state = "doubleverticalcorroded"
+	},
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "verticalinnermain1"
+	},
+/area/f13/tunnel/northeast)
 "tGQ" = (
 /obj/structure/flora/grass/wasteland{
 	icon_state = "tall_grass_2";
@@ -51964,6 +52526,13 @@
 /obj/structure/flora/junglebush/large,
 /turf/open/water,
 /area/f13/wasteland/valley)
+"tWs" = (
+/obj/machinery/light/floor,
+/obj/structure/chair/sofa/corner{
+	dir = 1
+	},
+/turf/open/floor/carpet/red,
+/area/f13/bar/heaven)
 "tWH" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "000000"
@@ -52151,6 +52720,12 @@
 	icon_state = "plating"
 	},
 /area/f13/building/firestation)
+"ucS" = (
+/obj/structure/car/rubbish1,
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "verticalinnermain1"
+	},
+/area/f13/wasteland/east)
 "ucT" = (
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "verticaloutermain1"
@@ -52198,7 +52773,7 @@
 "ufd" = (
 /obj/structure/car,
 /turf/open/indestructible/ground/outside/road{
-	icon_state = "verticalleftborderright0"
+	icon_state = "verticalleftborderright1"
 	},
 /area/f13/wasteland/east)
 "ufs" = (
@@ -52482,6 +53057,12 @@
 	icon_state = "darkrusty"
 	},
 /area/f13/building/firestation)
+"upd" = (
+/obj/effect/overlay/desert/sonora/edge/corner{
+	dir = 4
+	},
+/turf/open/floor/plating/dirt,
+/area/f13/wasteland/train)
 "upn" = (
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "verticalleftborderleft1"
@@ -52802,12 +53383,13 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
 "uxL" = (
-/obj/structure/chair/sofa/corp/corner{
-	dir = 8
+/obj/effect/decal/marking{
+	icon_state = "doublehorizontal"
 	},
-/obj/machinery/light/floor,
-/turf/open/floor/carpet/red,
-/area/f13/bar/heaven)
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "verticalrightborderleft0"
+	},
+/area/f13/wasteland/massfusion)
 "uxW" = (
 /obj/structure/curtain{
 	pixel_x = 32
@@ -53030,7 +53612,7 @@
 "uEv" = (
 /obj/structure/reagent_dispensers/barrel/dangerous,
 /turf/open/indestructible/ground/outside/road{
-	icon_state = "horizontalinnermain0"
+	icon_state = "verticalinnermain0"
 	},
 /area/f13/wasteland/massfusion)
 "uEx" = (
@@ -53894,11 +54476,19 @@
 /area/f13/building)
 "vbx" = (
 /obj/structure/railing{
-	dir = 1
+	layer = 3.3;
+	plane = -3;
+	dir = 6
 	},
-/obj/structure/chair/sofa/corp/corner,
-/obj/machinery/light/floor,
-/turf/open/floor/carpet/red,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/structure/chair/booth{
+	dir = 8
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	name = "metal plating"
+	},
 /area/f13/bar/heaven)
 "vbE" = (
 /obj/effect/decal/cleanable/dirt/dust,
@@ -53939,7 +54529,7 @@
 	},
 /mob/living/simple_animal/hostile/raider/thief,
 /turf/open/indestructible/ground/outside/road{
-	icon_state = "horizontalinnermain0"
+	icon_state = "verticalinnermain1"
 	},
 /area/f13/wasteland/east)
 "vdB" = (
@@ -54137,7 +54727,7 @@
 	dir = 4
 	},
 /turf/open/indestructible/ground/outside/road{
-	icon_state = "horizontalinnermain0"
+	icon_state = "verticalrightborderleft0"
 	},
 /area/f13/wasteland/east)
 "vlr" = (
@@ -54218,6 +54808,13 @@
 	icon_state = "horizontalinnermain2right"
 	},
 /area/f13/wasteland/hospital)
+"vod" = (
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/structure/closet/crate/bin/trashbin,
+/turf/open/floor/wood,
+/area/f13/bar/heaven)
 "voA" = (
 /obj/structure/closet,
 /obj/effect/decal/cleanable/dirt,
@@ -54241,7 +54838,9 @@
 /area/f13/building)
 "vpl" = (
 /obj/structure/junk/locker,
-/turf/open/indestructible/ground/outside/sidewalk,
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "horizontaloutermain0"
+	},
 /area/f13/wasteland/west)
 "vpy" = (
 /obj/machinery/light{
@@ -54725,6 +55324,14 @@
 /obj/machinery/light/floor,
 /turf/open/floor/plasteel/white/side,
 /area/f13/brotherhood)
+"vEF" = (
+/obj/effect/decal/marking{
+	icon_state = "doubleverticalbottom"
+	},
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "verticalinnermain1"
+	},
+/area/f13/wasteland/train)
 "vEX" = (
 /obj/structure/simple_door/wood,
 /turf/open/floor/f13/wood,
@@ -54782,6 +55389,12 @@
 	icon_state = "bar"
 	},
 /area/f13/building)
+"vIb" = (
+/obj/structure/railing/dancing_pole/top,
+/turf/open/floor/plasteel/cult{
+	name = "stage floor"
+	},
+/area/f13/bar/heaven)
 "vIl" = (
 /obj/effect/decal/cleanable/oil{
 	icon_state = "floor6";
@@ -55361,7 +55974,6 @@
 /obj/effect/turf_decal/stripes/red/line{
 	dir = 4
 	},
-/obj/structure/timeddoor/sixtyminute,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/wasteland/museum)
 "wbm" = (
@@ -55702,13 +56314,19 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13,
 /area/f13/building)
+"wkn" = (
+/obj/structure/car,
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "horizontalbottombordertop0"
+	},
+/area/f13/wasteland/museum)
 "wkv" = (
 /obj/structure/decoration/warning{
 	name = "WARNING: NO MANS LAND AHEAD PVP ZONE";
 	pixel_x = -32
 	},
 /turf/open/indestructible/ground/outside/road{
-	icon_state = "horizontalinnermain0"
+	icon_state = "verticalleftborderright0"
 	},
 /area/f13/tunnel/northeast)
 "wkF" = (
@@ -56019,7 +56637,7 @@
 	icon_state = "tall_grass_2"
 	},
 /turf/open/indestructible/ground/outside/road{
-	icon_state = "hole"
+	icon_state = "verticalrightborderleft0"
 	},
 /area/f13/wasteland/massfusion)
 "wso" = (
@@ -56079,6 +56697,15 @@
 /obj/effect/decal/remains/human,
 /turf/open/floor/plasteel/f13/vault_floor/neutral/neutralchess/neutralchess2,
 /area/f13/building/firestation)
+"wvR" = (
+/obj/machinery/door/poddoor/shutters/old{
+	id = "factorygate";
+	name = "road barrier"
+	},
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "verticalinnermain0"
+	},
+/area/f13/wasteland/massfusion)
 "wwj" = (
 /obj/effect/decal/cleanable/blood/old{
 	icon_state = "gib2-old"
@@ -56316,17 +56943,9 @@
 /turf/open/floor/plasteel/freezer,
 /area/f13/brotherhood/leisure)
 "wCJ" = (
-/obj/structure/chair/greyscale{
-	dir = 1
-	},
-/obj/structure/camera_assembly{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/dirt{
-	color = "000000"
-	},
-/turf/open/floor/f13/wood,
-/area/f13/building)
+/obj/effect/turf_decal/weather/dirt,
+/turf/open/indestructible/ground/outside/water,
+/area/f13/wasteland/train)
 "wCK" = (
 /obj/machinery/workbench,
 /turf/open/floor/f13{
@@ -56334,13 +56953,13 @@
 	},
 /area/f13/building)
 "wCN" = (
-/obj/structure/nest/protectron{
-	layer = 3;
-	max_mobs = 1;
-	pixel_y = 20
+/obj/effect/decal/marking{
+	icon_state = "doublevertical"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/floor,
-/area/f13/village)
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "verticalinnermain1"
+	},
+/area/f13/wasteland/east)
 "wCS" = (
 /obj/structure/table/reinforced,
 /obj/effect/decal/cleanable/dirt,
@@ -56440,6 +57059,11 @@
 	icon_state = "bluerustysolid"
 	},
 /area/f13/building/museum)
+"wGk" = (
+/turf/open/indestructible/ground/outside/desert{
+	icon_state = "wasteland32"
+	},
+/area/f13/ruins)
 "wGr" = (
 /obj/structure/chair,
 /obj/effect/decal/cleanable/dirt,
@@ -56503,8 +57127,12 @@
 /turf/open/floor/plasteel/freezer,
 /area/f13/brotherhood)
 "wHT" = (
-/obj/structure/railing/dancing_pole,
-/turf/open/floor/vault,
+/obj/structure/railing{
+	layer = 3.5
+	},
+/turf/open/floor/plasteel/cult{
+	name = "stage floor"
+	},
 /area/f13/bar/heaven)
 "wIc" = (
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -56620,7 +57248,7 @@
 "wLX" = (
 /obj/structure/car,
 /turf/open/indestructible/ground/outside/road{
-	icon_state = "horizontalinnermain0"
+	icon_state = "verticalinnermain1"
 	},
 /area/f13/wasteland/train)
 "wMb" = (
@@ -56754,8 +57382,10 @@
 	},
 /area/f13/building/hospital)
 "wOu" = (
-/obj/structure/flora/grass/wasteland,
-/turf/open/indestructible/ground/outside/dirt,
+/obj/effect/overlay/desert/sonora/edge{
+	dir = 8
+	},
+/turf/open/floor/plating/dirt,
 /area/f13/wasteland/train)
 "wOA" = (
 /obj/structure/handrail/g_central{
@@ -57142,6 +57772,12 @@
 /obj/item/clothing/under/f13/raiderrags,
 /turf/open/floor/f13,
 /area/f13/building)
+"xad" = (
+/obj/effect/turf_decal/weather/dirt{
+	dir = 9
+	},
+/turf/open/indestructible/ground/outside/water,
+/area/f13/wasteland/train)
 "xaj" = (
 /obj/structure/simple_door/glass,
 /turf/open/floor/f13{
@@ -57156,7 +57792,9 @@
 	},
 /area/f13/wasteland/bighorn)
 "xar" = (
-/obj/structure/table/reinforced,
+/obj/structure/chair/sofa{
+	dir = 1
+	},
 /turf/open/floor/carpet/red,
 /area/f13/bar/heaven)
 "xaK" = (
@@ -57239,6 +57877,14 @@
 	icon_state = "darkrusty"
 	},
 /area/f13/building/massfusion)
+"xcq" = (
+/obj/effect/decal/marking{
+	icon_state = "doubleverticalbottom"
+	},
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "verticalinnermain1"
+	},
+/area/f13/wasteland/east)
 "xcF" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_x = -28
@@ -57349,6 +57995,12 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/building)
+"xff" = (
+/obj/structure/barricade/sandbags,
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "verticalleftborderright0"
+	},
+/area/f13/wasteland/massfusion)
 "xfj" = (
 /obj/machinery/autolathe/ammo,
 /obj/item/stack/sheet/metal,
@@ -57558,6 +58210,12 @@
 	icon_state = "verticalleftborderright2"
 	},
 /area/f13/wasteland/bighorn)
+"xoc" = (
+/mob/living/simple_animal/hostile/molerat,
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "verticalrightborderleft0"
+	},
+/area/f13/building/massfusion)
 "xoi" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -57691,6 +58349,15 @@
 	icon_state = "bluedirtychess"
 	},
 /area/f13/building/mall)
+"xsQ" = (
+/obj/structure/window/fulltile/ruins{
+	icon_state = "ruinswindowvertical"
+	},
+/obj/structure/barricade/bars{
+	layer = 3.21
+	},
+/turf/open/floor/f13/wood,
+/area/f13/bar/heaven)
 "xta" = (
 /obj/structure/wreck/trash/autoshaft,
 /turf/open/indestructible/ground/outside/dirt,
@@ -58225,6 +58892,11 @@
 	icon_state = "horizontaloutermain2"
 	},
 /area/f13/wasteland/firestation)
+"xIa" = (
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "outerpavementcorner"
+	},
+/area/f13/wasteland/train)
 "xIY" = (
 /turf/open/floor/wood/wood_worn,
 /area/f13/city/bighorn)
@@ -58561,6 +59233,12 @@
 	},
 /turf/open/floor/carpet,
 /area/f13/building)
+"xTs" = (
+/obj/item/ammo_casing/c10mm,
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "verticalinnermain0"
+	},
+/area/f13/wasteland/train)
 "xTE" = (
 /obj/structure/fence{
 	dir = 4
@@ -58981,10 +59659,16 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "yhh" = (
-/obj/structure/chair/sofa/corp/right{
-	dir = 1
+/obj/machinery/light/small{
+	dir = 1;
+	light_color = "red"
 	},
-/turf/open/floor/carpet/red,
+/obj/structure/railing{
+	dir = 8
+	},
+/turf/open/floor/plasteel/cult{
+	name = "stage floor"
+	},
 /area/f13/bar/heaven)
 "yhm" = (
 /obj/structure/barricade/bars,
@@ -68227,14 +68911,14 @@ wEd
 aAm
 wEd
 wEd
-flC
+sEB
 wEd
 jzD
 eNJ
 kyU
 pUh
 wEd
-flC
+sEB
 wEd
 wEd
 wEd
@@ -70268,7 +70952,7 @@ sfD
 xCM
 wEd
 wEd
-wEd
+sEB
 wEd
 wEd
 wEd
@@ -72542,17 +73226,17 @@ aae
 aae
 aae
 aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
-aae
+cwh
+cwh
+cwh
+cwh
+cwh
+cwh
+cwh
+cwh
+cwh
+cwh
+cwh
 aae
 aae
 aae
@@ -72799,7 +73483,7 @@ aae
 aae
 aae
 aae
-aae
+cwh
 ucu
 uRS
 uRS
@@ -72862,7 +73546,7 @@ wEd
 wEd
 wEd
 wEd
-wEd
+sEB
 wEd
 wEd
 wEd
@@ -73056,7 +73740,7 @@ aae
 aae
 aae
 aae
-aae
+cwh
 ucu
 ucu
 uRS
@@ -73183,12 +73867,12 @@ aYl
 aHz
 aYl
 aXW
-sHf
-sHf
+vod
+lGu
 aBK
 aXW
 bbD
-aNg
+aEk
 aXW
 aXW
 aXW
@@ -73197,7 +73881,7 @@ aXW
 aXW
 aXW
 aXW
-aXW
+nvE
 nvE
 nvE
 nvE
@@ -73313,7 +73997,7 @@ aae
 aae
 aae
 aae
-aae
+cwh
 eWB
 ucu
 aaQ
@@ -73441,8 +74125,8 @@ aHz
 aYl
 aXW
 aqv
-sHf
-sHf
+lGu
+lGu
 aEk
 baA
 baA
@@ -73452,9 +74136,9 @@ aYW
 sdg
 sdg
 aBM
-bQL
-aLh
+tWs
 aXW
+nvE
 nvE
 nvE
 nvE
@@ -73507,7 +74191,7 @@ jZx
 pWU
 pWU
 pWU
-pWU
+lEf
 mGE
 dtk
 mGE
@@ -73627,7 +74311,7 @@ wEd
 wEd
 wEd
 wEd
-wEd
+sEB
 wEd
 wEd
 wEd
@@ -73698,20 +74382,20 @@ anx
 anx
 aXW
 aqw
-sHf
-sHf
+lGu
+lGu
 aES
 baA
 baA
 gft
 mSq
-xar
+aNg
 sdg
 sdg
+axZ
 xar
-xar
-aQe
 aXW
+nvE
 nvE
 nvE
 nvE
@@ -73922,9 +74606,9 @@ aae
 czi
 czi
 czi
-czi
-nIX
-pTt
+nyd
+iTb
+gDC
 czi
 baD
 ikm
@@ -73955,20 +74639,20 @@ ans
 ans
 aXW
 aqV
-sHf
-sHf
+lGu
+lGu
 aGf
 bbK
 baA
-iNZ
-xar
-aMV
+mDv
+bTD
+axZ
 sdg
 sdg
 aMV
-xar
-bhI
+mYd
 aXW
+nvE
 nvE
 nvE
 nvE
@@ -74180,8 +74864,8 @@ czi
 czi
 czi
 tAk
-ePl
-cqC
+xnl
+gDC
 nyd
 ePl
 nIX
@@ -74212,20 +74896,20 @@ sHf
 apy
 aXW
 avj
-sHf
-sHf
+lGu
+lGu
 aHw
 bbK
 baA
+aQe
 sdg
 sdg
 sdg
-sdg
-aDR
 sdg
 sdg
 sdg
 aXW
+vIz
 vIz
 vIz
 vIz
@@ -74438,7 +75122,7 @@ czi
 baq
 nIX
 ikm
-uKQ
+gDC
 tAk
 gDC
 czi
@@ -74474,15 +75158,15 @@ aDP
 aJO
 bbK
 baA
-lQs
-sdg
+mQk
+dAY
 sdg
 dwe
 mMr
 sdg
-sdg
-sdg
-aXW
+ntr
+quQ
+hqc
 hqc
 hqc
 hqc
@@ -74695,7 +75379,7 @@ czi
 czi
 czi
 tAk
-ePl
+gDC
 nIX
 uKQ
 czi
@@ -74730,16 +75414,16 @@ bbK
 bbK
 bbK
 baA
-dCu
-aYo
-sdg
+baA
+gft
+ljj
 sdg
 fWE
 ciQ
 sdg
-sdg
-sdg
-aXW
+ntr
+quQ
+hqc
 hqc
 kTq
 ohI
@@ -74952,7 +75636,7 @@ czi
 czi
 czi
 nIX
-xnl
+pTt
 ePl
 czi
 nyd
@@ -74989,22 +75673,22 @@ baA
 baA
 baA
 mDv
+rrf
 sdg
-aDR
 aZu
 dEM
-aDR
 sdg
-sdg
-aXW
+ntr
+quQ
+hqc
 hqc
 pjb
-ibe
-ibe
-ibe
-ibe
-ibe
-ibe
+dSW
+gvW
+gvW
+gvW
+gvW
+gvW
 ghQ
 hqc
 uiC
@@ -75214,8 +75898,8 @@ aae
 aae
 aae
 gtu
-aae
-aae
+xnl
+xnl
 aae
 aae
 aae
@@ -75241,12 +75925,11 @@ ans
 aXW
 aYZ
 baC
-baC
+aYZ
 bbm
 baA
 baA
-sdg
-sdg
+aQe
 sdg
 sdg
 sdg
@@ -75255,8 +75938,9 @@ sdg
 sdg
 aXW
 hqc
+hqc
 pjb
-ibe
+fWZ
 ibe
 tHz
 ibe
@@ -75399,7 +76083,7 @@ vOV
 vOV
 pUh
 uki
-uRS
+qXW
 czG
 czG
 mvK
@@ -75496,24 +76180,24 @@ sHf
 sHf
 aga
 aXW
-baO
+yhh
 baO
 baE
-bcO
+bwn
 baA
 baA
 mQk
-xar
+oYn
 axZ
 sdg
 sdg
 aMV
-xar
-yhh
+dCh
 aXW
 hqc
+hqc
 pjb
-dTV
+aYo
 dTV
 dTV
 ibe
@@ -75753,24 +76437,24 @@ sHf
 sHf
 sHf
 aMI
-baO
+vIb
 aZW
 wHT
-bcO
+baA
 baA
 baA
 gft
-nnF
-xar
+mSq
+gqr
 sdg
 sdg
+axZ
 xar
-xar
-aQe
 aXW
 hqc
+hqc
 pjb
-ibe
+fWZ
 bdX
 ibe
 pBa
@@ -75949,7 +76633,7 @@ vOV
 pUh
 wEd
 wEd
-flC
+sEB
 wEd
 wEd
 wEd
@@ -76008,26 +76692,26 @@ ans
 aeG
 ajv
 sHf
-alr
+aDR
 aXW
-baO
-baO
-baO
+eGX
+iIb
+nnF
 bcO
 baA
 baA
 vbx
-ghI
+jHR
 rfd
 qjq
 qjq
 aOk
 ghI
-uxL
 aXW
 hqc
+hqc
 pjb
-ibe
+fWZ
 ibe
 ibe
 pBa
@@ -76122,7 +76806,7 @@ ajM
 ajM
 ajM
 ajM
-ais
+ajM
 ajM
 ajM
 ajM
@@ -76210,7 +76894,7 @@ wEd
 wEd
 wEd
 wEd
-flC
+sEB
 wEd
 aae
 aae
@@ -76265,26 +76949,26 @@ ans
 aeG
 ajv
 sHf
-alr
+mvQ
 aXW
 bgJ
 bbf
-bbf
+bgJ
 bdq
 baA
 baA
 aXW
 aXW
 aXW
-aKf
-aKf
+xsQ
+xsQ
 aXW
 aXW
 aXW
-aXW
+mgw
 tbu
 pjb
-dTV
+aYo
 dTV
 dTV
 hDy
@@ -76427,7 +77111,7 @@ wEd
 wEd
 wEd
 uki
-uRS
+wBe
 hvO
 hvO
 wOD
@@ -76535,13 +77219,13 @@ apF
 ndu
 hqc
 hqc
+hqc
 oRI
 bcq
 bcA
 oRI
-hqc
 pjb
-ibe
+fWZ
 ibe
 ibe
 ibe
@@ -76792,13 +77476,13 @@ apF
 ndu
 hqc
 hqc
+hqc
 oRI
 bcr
 ahM
 oRI
-hqc
 pjb
-tJr
+ezG
 ibe
 ibe
 ibe
@@ -77047,15 +77731,15 @@ aXW
 aXW
 aXW
 aXW
-fZL
+hqc
+hqc
 hqc
 laM
 hqc
 hqc
 oRI
-hqc
 pjb
-dTV
+aYo
 dTV
 dTV
 ibe
@@ -77301,18 +77985,18 @@ hqc
 hqc
 hqc
 hqc
+hqc
 cps
-mbs
-aXW
+jiT
 cqZ
 hqc
-oRI
-hqc
 hqc
 oRI
 hqc
+hqc
+oRI
 pjb
-ibe
+fWZ
 eMz
 ibe
 ibe
@@ -77529,7 +78213,7 @@ aaa
 aae
 xnl
 xnl
-bpX
+xnl
 xnl
 xnl
 xnl
@@ -77563,15 +78247,15 @@ cqZ
 cqZ
 cqZ
 hqc
+hqc
 oRI
 vBL
 pdR
 oRI
-hqc
 pjb
-ibe
-ibe
-ibe
+lki
+bhb
+bhb
 ibe
 ibe
 ibe
@@ -77669,7 +78353,7 @@ ajM
 ajM
 ajM
 ajM
-ajM
+xya
 aCK
 ajM
 ajM
@@ -77818,18 +78502,18 @@ cqZ
 cqZ
 cqZ
 cqZ
+sYy
 hqc
 hqc
-hKY
+nTX
 mgw
 mgw
 oCO
-hqc
 nmJ
 woT
 woT
 ruf
-ibe
+fWZ
 ibe
 ibe
 ghQ
@@ -77926,7 +78610,7 @@ ajM
 qDT
 ajM
 ajM
-xya
+ajM
 ajM
 ajM
 ajM
@@ -78003,7 +78687,7 @@ wEd
 wEd
 wEd
 wEd
-wEd
+sEB
 wEd
 wEd
 wEd
@@ -78086,7 +78770,7 @@ tzo
 ohI
 ohI
 nLc
-ibe
+fWZ
 ibe
 ibe
 rUP
@@ -78106,7 +78790,7 @@ mvK
 mvK
 nwr
 dcT
-ifg
+lVn
 mbv
 nzp
 pak
@@ -78305,23 +78989,23 @@ wEd
 wEd
 aKV
 qQD
-daa
-daa
-daa
-daa
-daa
-daa
-daa
-daa
-daa
+wzC
+wzC
+qQD
+tCl
+wzC
+wzC
+lKy
+tCl
+tCl
 gvW
 gvW
-gvW
-gvW
-gvW
-gvW
-gvW
-gvW
+ofD
+ofD
+vxU
+pFj
+pFj
+pFj
 cvM
 gvW
 aXY
@@ -78343,7 +79027,7 @@ gvW
 gvW
 vxU
 gvW
-ibe
+nCu
 ibe
 bdX
 pFj
@@ -78362,9 +79046,9 @@ cFy
 wzC
 lKy
 lKy
-ifg
-ifg
-ifg
+lVn
+lVn
+mbv
 aod
 pak
 ahx
@@ -78562,23 +79246,23 @@ wEd
 wEd
 aqn
 aqm
-ifg
-ifg
-ifg
-ifg
-ifg
-ifg
-ifg
-ifg
-ifg
+kWn
+kWn
+kWn
+dOJ
+dOJ
+dOJ
+dOJ
+dOJ
+dOJ
 lsJ
-lsJ
-lsJ
-lsJ
-lsJ
+fMp
+fMp
+bIO
+bIO
 tHz
-lsJ
-lsJ
+bIO
+bIO
 bIO
 vwL
 lsJ
@@ -78600,9 +79284,9 @@ lsJ
 tHz
 lsJ
 lsJ
-lsJ
-lsJ
-lsJ
+ibe
+ibe
+ibe
 lsJ
 lsJ
 sNW
@@ -78619,9 +79303,9 @@ kWn
 kWn
 kWn
 ifg
-ifg
+lVn
 aat
-ifg
+mbv
 nuM
 pak
 ygj
@@ -78779,7 +79463,7 @@ wEd
 wEd
 wEd
 wEd
-wEd
+sEB
 wEd
 wEd
 wEd
@@ -78819,20 +79503,20 @@ wEd
 wEd
 wEd
 aGY
-yid
-yid
-yid
-yid
-yid
-yid
-yid
-yid
-yid
-bhb
-bhb
-bhb
-bhb
-bhb
+iHA
+iHA
+iHA
+iHA
+rFo
+rFo
+age
+rFo
+rFo
+ucr
+ucr
+ucr
+ucr
+ucr
 bhb
 bhb
 ivt
@@ -78856,10 +79540,10 @@ bhb
 bhb
 ucr
 pja
-lsJ
-lsJ
-lsJ
-lsJ
+bhb
+dSD
+ibe
+ibe
 lsJ
 lsJ
 lsJ
@@ -78876,9 +79560,9 @@ rFo
 iWF
 age
 rFo
-ifg
-ifg
-ifg
+lVn
+lVn
+mbv
 aod
 pak
 ygj
@@ -80133,7 +80817,7 @@ nvE
 nvE
 hyv
 nvE
-nvE
+fwl
 nvE
 nvE
 bcE
@@ -80796,7 +81480,7 @@ afz
 apZ
 ajM
 ajM
-ajM
+wGk
 ajM
 ajM
 afz
@@ -81603,9 +82287,9 @@ wEd
 wEd
 wEd
 wEd
-flC
+sEB
 wEd
-flC
+sEB
 wEd
 wEd
 wEd
@@ -82114,7 +82798,7 @@ azh
 wEd
 wEd
 wEd
-flC
+sEB
 wEd
 wEd
 wEd
@@ -82494,7 +83178,7 @@ aaa
 aae
 aae
 aae
-uRS
+wEd
 wEd
 wEd
 wEd
@@ -82750,8 +83434,8 @@ aaa
 aae
 aae
 aae
-uRS
-uRS
+wEd
+wEd
 wEd
 wEd
 wEd
@@ -83005,10 +83689,10 @@ aae
 gMF
 aae
 aae
-uRS
-uRS
-uRS
-uRS
+rnk
+rnk
+rnk
+rnk
 rnk
 rnk
 rnk
@@ -84887,15 +85571,15 @@ bOA
 lVn
 mbv
 nzp
-uRS
-uRS
-uRS
+vsg
+vsg
+vsg
 jgz
 jgz
 bog
-uRS
-uRS
-uRS
+vsg
+vsg
+vsg
 aae
 aae
 aae
@@ -85144,14 +85828,14 @@ lVn
 lVn
 mbv
 nzp
-uRS
+vsg
 jgz
 jgz
 eWB
 eWB
 jgz
 jgz
-uRS
+vsg
 aae
 aae
 aae
@@ -85401,7 +86085,7 @@ ifg
 ifg
 ifg
 nzp
-uRS
+vsg
 jgz
 eWB
 sCC
@@ -85915,8 +86599,8 @@ vxN
 vxN
 vxN
 gjk
-uRS
-uRS
+vsg
+vsg
 jgz
 eWB
 eWB
@@ -86165,14 +86849,14 @@ afF
 uRS
 uRS
 jgz
-uRS
-uRS
+vsg
+vsg
 jgz
 jgz
 aif
-uRS
-uRS
-uRS
+vsg
+vsg
+vsg
 jgz
 jgz
 jgz
@@ -86422,17 +87106,17 @@ aft
 jgz
 jgz
 jgz
-uRS
+vsg
 jgz
 jgz
-uRS
-uRS
-uRS
-uRS
+vsg
+vsg
+vsg
+vsg
 jgz
-uRS
+vsg
 jgz
-uRS
+vsg
 jgz
 aae
 aae
@@ -86687,7 +87371,7 @@ jgz
 jgz
 jgz
 aiR
-uRS
+vsg
 jgz
 jgz
 jgz
@@ -86855,7 +87539,7 @@ aae
 wEd
 wEd
 wEd
-wEd
+sEB
 wEd
 wEd
 wEd
@@ -86938,12 +87622,12 @@ sCC
 tJl
 jgz
 jgz
-uRS
-uRS
+vsg
+vsg
 jgz
 jgz
 jgz
-uRS
+vsg
 jgz
 jgz
 jgz
@@ -87195,17 +87879,17 @@ agN
 ahc
 eWB
 jgz
-uRS
+vsg
 jgz
-uRS
-uRS
-jgz
-jgz
+vsg
+vsg
 jgz
 jgz
 jgz
 jgz
-uRS
+jgz
+jgz
+vsg
 aae
 aae
 aae
@@ -87312,7 +87996,7 @@ wEd
 wEd
 wEd
 wEd
-wEd
+sEB
 wEd
 wEd
 wEd
@@ -87454,7 +88138,7 @@ eWB
 jgz
 jgz
 jgz
-uRS
+vsg
 jgz
 jgz
 eWB
@@ -87462,7 +88146,7 @@ eWB
 jgz
 jgz
 jgz
-uRS
+vsg
 jgz
 aae
 aae
@@ -87708,7 +88392,7 @@ aae
 jgz
 jgz
 jgz
-uRS
+vsg
 jgz
 jgz
 jgz
@@ -87880,7 +88564,7 @@ aae
 wEd
 wEd
 wEd
-wEd
+sEB
 wEd
 wEd
 wEd
@@ -87917,7 +88601,7 @@ gYz
 wEd
 wEd
 wEd
-wEd
+sEB
 wEd
 wEd
 wEd
@@ -87977,8 +88661,8 @@ jgz
 jgz
 jgz
 jgz
-uRS
-uRS
+vsg
+vsg
 xyC
 wEd
 gYz
@@ -88220,20 +88904,20 @@ aaa
 aae
 aae
 aae
-uRS
+vsg
 jgz
 jgz
 jgz
-uRS
+vsg
 jgz
-uRS
+vsg
 jgz
 eWB
 eWB
 jgz
 jgz
 jgz
-uRS
+vsg
 jgz
 jgz
 eRk
@@ -88436,7 +89120,7 @@ wEd
 wEd
 wEd
 wEd
-wEd
+sEB
 wEd
 wEd
 wEd
@@ -88490,7 +89174,7 @@ jgz
 jgz
 jgz
 jgz
-uRS
+vsg
 jgz
 jgz
 xyC
@@ -88737,8 +89421,8 @@ aae
 aae
 aae
 jgz
-uRS
-uRS
+vsg
+vsg
 jgz
 jgz
 jgz
@@ -88749,7 +89433,7 @@ jgz
 jgz
 jgz
 jgz
-uRS
+vsg
 eRk
 amE
 eRk
@@ -88995,18 +89679,18 @@ aae
 aae
 aae
 jgz
-uRS
+vsg
 aqP
 tMD
 cUq
 qdy
 uKS
 jgz
-uRS
+vsg
 jgz
 jgz
 jgz
-uRS
+vsg
 xyC
 wEd
 gYz
@@ -89167,7 +89851,7 @@ wEd
 wEd
 wEd
 wEd
-wEd
+sEB
 wEd
 wEd
 wEd
@@ -89185,7 +89869,7 @@ wEd
 wEd
 wEd
 wEd
-wEd
+sEB
 wEd
 wEd
 wEd
@@ -89259,7 +89943,7 @@ lLJ
 lLJ
 aaD
 aaD
-uRS
+vsg
 jgz
 sCC
 tJl
@@ -89419,7 +90103,7 @@ wEd
 wEd
 wEd
 wEd
-wEd
+sEB
 wEd
 wEd
 wEd
@@ -89666,7 +90350,7 @@ daa
 daa
 cFy
 wzC
-kYj
+wzC
 daa
 daa
 daa
@@ -89777,7 +90461,7 @@ vpl
 jgz
 jgz
 jgz
-uRS
+vsg
 aae
 aae
 aae
@@ -90031,8 +90715,8 @@ lqQ
 xHo
 aaD
 aae
-uRS
-uRS
+vsg
+vsg
 aae
 aae
 aae
@@ -90217,7 +90901,7 @@ jns
 jns
 jns
 jns
-jns
+qgl
 jns
 jns
 jns
@@ -90432,7 +91116,7 @@ hvO
 hvO
 vxN
 cqb
-ifg
+dcT
 lVn
 lVn
 lVn
@@ -90440,7 +91124,7 @@ lVn
 lVn
 lVn
 lVn
-lVn
+mbv
 nzp
 pak
 wEd
@@ -90488,7 +91172,7 @@ jns
 jns
 jns
 jns
-jns
+qgl
 jns
 jns
 jns
@@ -90689,6 +91373,7 @@ jgz
 jgz
 jgz
 bFF
+dcT
 lVn
 lVn
 lVn
@@ -90696,8 +91381,7 @@ lVn
 lVn
 lVn
 lVn
-lVn
-lVn
+mbv
 nzp
 pak
 jzD
@@ -90726,6 +91410,7 @@ kHQ
 jns
 jns
 jns
+qgl
 jns
 jns
 jns
@@ -90733,12 +91418,11 @@ jns
 jns
 jns
 jns
+qgl
 jns
 jns
 jns
-jns
-jns
-jns
+qgl
 jns
 jns
 jns
@@ -90924,29 +91608,29 @@ wEd
 wEd
 wEd
 uki
-jgz
-jgz
-jgz
-jgz
-jgz
-jgz
-jgz
-jgz
-jgz
-jgz
-jgz
-jgz
-jgz
-jgz
-jgz
-jgz
-jgz
-jgz
-jgz
-jgz
-jgz
+blg
+bux
+okl
+blg
+aTs
+blg
+twa
+blg
+hBB
+lih
+blg
+blg
+blg
+lWN
+blg
+blg
+blg
+gvR
+kXp
+aQd
+aod
 bFF
-lVn
+dcT
 lVn
 lVn
 lVn
@@ -90954,7 +91638,7 @@ kVA
 lVn
 lVn
 lVn
-lVn
+mbv
 nzp
 pak
 xOD
@@ -91181,29 +91865,29 @@ wEd
 wEd
 wEd
 uki
-jgz
-jgz
-eWB
-eWB
-jgz
-jgz
-eWB
-eWB
-eWB
-jgz
-jgz
-fEW
-jgz
-jgz
-jgz
-jgz
-eWB
-eWB
-eWB
-jgz
-jgz
+blg
+vxj
+aiG
+blg
+faP
+dqz
+eML
+fKS
+tCl
+eZr
+blg
+blg
+rVL
+mea
+lIs
+blg
+rgz
+eML
+eML
+twa
+aod
 bFF
-lVn
+dcT
 lVn
 lVn
 lVn
@@ -91211,7 +91895,7 @@ bun
 lVn
 kYj
 lVn
-lVn
+mbv
 nzp
 pak
 wWc
@@ -91421,7 +92105,7 @@ aaQ
 wEd
 wEd
 wEd
-wEd
+sEB
 wEd
 wEd
 jzD
@@ -91439,28 +92123,28 @@ wEd
 wEd
 uki
 blg
-bux
-okl
+afS
+aAi
+afS
+xyU
+eML
+xyU
+bkO
+bOA
+qfX
 blg
-aTs
-blg
-twa
-blg
-hBB
-lih
-blg
-blg
-blg
-lWN
-blg
-blg
-blg
-gvR
-kXp
-aQd
+oMw
+bng
+bng
+bng
+wiK
+eML
+eML
+bLX
+xJE
 aod
 bFF
-hlD
+axG
 lVn
 lVn
 lVn
@@ -91468,7 +92152,7 @@ ciq
 lVn
 lVn
 lVn
-lVn
+mbv
 nzp
 pak
 wEd
@@ -91686,38 +92370,38 @@ lRa
 pUh
 wEd
 wEd
-wEd
+sEB
 wEd
 xOD
 vOV
 pUh
 wEd
-wEd
+sEB
 wEd
 uki
 blg
-vxj
-aiG
-blg
-faP
-dqz
-eML
-blg
-tCl
-eZr
-blg
-blg
-rVL
-nzi
-lIs
-blg
-rgz
+csW
+aAi
+afS
 eML
 eML
-twa
+xyU
+blg
+bOA
+qfX
+blg
+jkL
+avO
+qHb
+cBX
+hAm
+eML
+eML
+eML
+aQd
 aod
 kIn
-lGu
+axB
 lVn
 lVn
 kYj
@@ -91725,7 +92409,7 @@ kVA
 lVn
 lVn
 lVn
-lVn
+mbv
 nzp
 pak
 pZV
@@ -91954,27 +92638,27 @@ wEd
 uki
 blg
 afS
-aAi
 afS
-xyU
+gKt
 eML
-xyU
-bkO
-bOA
-qfX
+aTJ
+aTJ
 blg
-oMw
+rGi
+ahQ
+blg
+omt
 bng
+bmA
 bng
-bng
-wiK
-eML
-eML
-bLX
-xJE
+rqF
+xeS
+bcJ
+lwR
+ruV
 aod
 pXv
-lVn
+dcT
 kYj
 lVn
 lVn
@@ -91982,7 +92666,7 @@ kVA
 lVn
 lVn
 lVn
-lVn
+mbv
 nzp
 pak
 jns
@@ -92210,28 +92894,28 @@ wEd
 wEd
 uki
 blg
-csW
+lLA
 aAi
-afS
-eML
-eML
+hPC
 xyU
+nQO
+aTJ
 blg
-bOA
-qfX
+rGi
+bkM
 blg
-jkL
+qlb
+bng
 avO
-qHb
-cBX
-hAm
+bng
+rrW
 eML
 eML
 lvq
-aQd
+jvG
 aod
 pXv
-lVn
+dcT
 kYj
 lVn
 lVn
@@ -92239,7 +92923,7 @@ ciq
 lVn
 lVn
 lVn
-lVn
+mbv
 nzp
 pak
 iSC
@@ -92467,28 +93151,28 @@ cpx
 cpx
 pkJ
 blg
+bwN
 afS
-afS
-gKt
+bsS
 eML
-aTJ
-aTJ
+eML
+uWc
 blg
-rGi
 ahQ
 blg
-omt
+blg
+blg
+pYf
 bng
-bmA
-bng
+avO
 rqF
-xeS
-bcJ
-lvq
-ruV
+eMB
+wlv
+blg
+blg
 oDA
 gMM
-rmP
+cvo
 eiK
 rmP
 rmP
@@ -92496,7 +93180,7 @@ bfZ
 rmP
 rmP
 rmP
-rmP
+ify
 pMY
 dZL
 mpj
@@ -92724,28 +93408,28 @@ cpx
 cpx
 pkJ
 blg
-lLA
-aAi
-hPC
+blg
+eKk
+coj
 xyU
-nQO
-aTJ
+eML
+kxy
 blg
-rGi
-bkM
+nlf
 blg
-qlb
+mbe
+ugb
+bfv
 bng
 avO
 bng
-rrW
-eML
-eML
-wCJ
-jvG
+bng
+bng
+daq
+wTS
 njq
 crU
-rmP
+cvo
 rmP
 rmP
 rmP
@@ -92753,7 +93437,7 @@ bfZ
 rmP
 rmP
 acq
-rmP
+ify
 pMY
 dZL
 mpj
@@ -92979,30 +93663,30 @@ eBH
 cpx
 cpx
 cpx
-pkJ
+xHh
+uBw
 blg
-bwN
-afS
-bsS
-eML
-eML
-uWc
+tue
+xyU
+xyU
+xyU
+oQn
 blg
-ahQ
-blg
-blg
-blg
-kXR
+nlf
+bkO
+hWj
+qnu
+rEP
 bng
-avO
-rqF
-eMB
-wlv
-blg
-blg
+bng
+til
+bng
+bng
+hMO
+xjA
 njq
 crU
-rmP
+cvo
 rmP
 rmP
 adc
@@ -93010,7 +93694,7 @@ bfZ
 rmP
 rmP
 rmP
-rmP
+ify
 pMY
 dZL
 mpj
@@ -93219,7 +93903,7 @@ fbT
 aaQ
 cpx
 cpx
-cpx
+qRe
 cpx
 cpx
 cyZ
@@ -93236,30 +93920,30 @@ eBH
 cpx
 cpx
 cpx
+cpx
 pkJ
 blg
-blg
-eKk
-coj
-xyU
+lhV
 eML
-kxy
+hnQ
+eML
+rTS
 blg
 nlf
 blg
-mbe
-ugb
-bfv
-bng
+gPD
+rEP
+blT
 avO
-bng
-bng
-bng
-daq
-wTS
+qHb
+gUQ
+jac
+jac
+blg
+blg
 njq
 crU
-rmP
+cvo
 rmP
 rmP
 rmP
@@ -93267,7 +93951,7 @@ bgb
 rmP
 rmP
 rmP
-rmP
+ify
 pMY
 dZL
 mpj
@@ -93493,30 +94177,30 @@ eBH
 cpx
 cpx
 uFw
-xHh
-uBw
+cpx
+pkJ
 blg
-tue
+uxE
+eML
+mCJ
 xyU
-xyU
-xyU
-oQn
+cqg
 blg
 nlf
-bkO
-jmf
-qnu
+blg
+jLc
 rEP
+vzT
+cBX
 bng
-bng
-til
-bng
-bng
-hMO
-xjA
+peZ
+raG
+avw
+fPm
+blg
 njq
 crU
-rmP
+cvo
 rmP
 rmP
 rmP
@@ -93524,7 +94208,7 @@ bgc
 rmP
 rmP
 rmP
-rmP
+ify
 pMY
 dZL
 mpj
@@ -93546,7 +94230,7 @@ jns
 kpx
 jns
 jns
-jns
+qgl
 jns
 jns
 mpj
@@ -93753,23 +94437,23 @@ cpx
 cpx
 pkJ
 blg
-lhV
+rsf
 eML
-hnQ
+xyU
 eML
-rTS
+eZJ
 blg
 nlf
 blg
-elO
-rEP
-blT
-avO
-qHb
-gUQ
-jac
-jac
-blg
+spL
+kXR
+vvB
+bnh
+kKH
+bRI
+uze
+avw
+eHN
 blg
 njq
 ctc
@@ -93781,7 +94465,7 @@ bfZ
 rmP
 eiK
 rmP
-rmP
+ify
 pMY
 dZL
 mpj
@@ -93810,7 +94494,7 @@ mpj
 jns
 ckj
 jns
-jns
+qgl
 jns
 jns
 jns
@@ -94010,27 +94694,27 @@ cpx
 uFw
 pkJ
 blg
-uxE
-eML
-mCJ
-xyU
-cqg
 blg
-nlf
+uuZ
+aVU
+cyA
 blg
-jLc
-rEP
-vzT
-cBX
-bng
-peZ
-raG
+blg
+ahQ
+blg
+blg
+blg
+blg
+blg
+blg
+blg
+awC
+atj
 avw
-fPm
 blg
 njq
 crU
-rmP
+cvo
 rmP
 qPn
 qPn
@@ -94038,7 +94722,7 @@ bgd
 qPn
 qPn
 rmP
-rmP
+ify
 pMY
 dZL
 mpj
@@ -94266,28 +94950,28 @@ cpx
 cpx
 cpx
 pkJ
+gpS
 blg
-rsf
-eML
-xyU
-eML
-eZJ
 blg
-nlf
 blg
-spL
-moJ
-vvB
-bnh
-kKH
-bRI
-uze
-avw
-eHN
+blg
+blg
+pEN
+rGi
+jJV
+auZ
+npK
+fre
+odu
+uCa
+blg
+blg
+blg
+blg
 blg
 njq
 cmQ
-rmP
+cvo
 rmP
 rmP
 rmP
@@ -94295,7 +94979,7 @@ bfZ
 rmP
 rmP
 rmP
-rmP
+ify
 pMY
 dZL
 mpj
@@ -94522,29 +95206,29 @@ aaQ
 aaQ
 aaQ
 aaQ
-pkJ
-blg
-blg
-uuZ
-aVU
-cyA
-blg
-blg
-ahQ
-blg
-blg
-blg
-blg
-blg
-blg
-blg
-awC
-atj
-avw
-blg
+xHh
+uBw
+nAt
+qba
+wNn
+dnw
+dnw
+dnw
+dnw
+dnw
+dnw
+rGi
+eiK
+eiK
+rGi
+rGi
+eiK
+eiK
+eiK
+aEu
 pCy
 cmQ
-adc
+hlD
 aeY
 rmP
 rmP
@@ -94552,7 +95236,7 @@ bfZ
 rmP
 rmP
 rmP
-eiK
+ify
 pMY
 dZL
 mpj
@@ -94779,21 +95463,21 @@ aAf
 cnZ
 oUj
 aaQ
+cpx
 pkJ
-gpS
+nAt
+abP
+abP
+abP
+abP
+abP
+aTs
+abP
+abP
+bgt
+dnw
+bld
 blg
-blg
-blg
-blg
-blg
-pEN
-rGi
-jJV
-auZ
-npK
-fre
-odu
-uCa
 blg
 blg
 blg
@@ -94801,7 +95485,7 @@ blg
 blg
 pMY
 cmQ
-rmP
+cvo
 rmP
 agI
 rmP
@@ -94809,7 +95493,7 @@ aeY
 rmP
 rmP
 rmP
-rmP
+ify
 pMY
 dZL
 mpj
@@ -94831,7 +95515,7 @@ ftc
 doZ
 rOO
 uVJ
-xZN
+mbs
 ubS
 tjF
 mpj
@@ -95036,29 +95720,29 @@ aAf
 oUj
 ltX
 aLD
-xHh
-uBw
+bdj
+pkJ
 nAt
-qba
-wNn
-dnw
-dnw
-dnw
-dnw
-dnw
-dnw
-rGi
-eiK
-eiK
-rGi
-rGi
-eiK
-eiK
-eiK
-aEu
+kWz
+dJD
+xip
+xTE
+rOp
+lTt
+bkP
+abP
+abP
+bcX
+abP
+blg
+uvR
+mws
+aAi
+bml
+blg
 oDA
 gMM
-rmP
+cvo
 rmP
 rmP
 rmP
@@ -95066,7 +95750,7 @@ bfZ
 rmP
 rmP
 rmP
-rmP
+ify
 pMY
 dZL
 mpj
@@ -95088,7 +95772,7 @@ ftc
 jUo
 qpD
 xZN
-xZN
+mbs
 eGZ
 tjF
 mpj
@@ -95297,25 +95981,25 @@ cpx
 pkJ
 nAt
 abP
-abP
-abP
-abP
-abP
-csY
-abP
-abP
-bgt
-dnw
-bld
+mqy
+eML
+aWd
+eML
+eML
+aUz
+aqQ
+ajt
+eML
+boc
 blg
-blg
-blg
-blg
-blg
-blg
+afS
+afS
+gxa
+bml
+lzL
 gGi
 nAt
-rmP
+cvo
 rmP
 rmP
 rmP
@@ -95323,7 +96007,7 @@ bga
 rmP
 rmP
 rmP
-rmP
+ify
 pMY
 txm
 mpj
@@ -95345,7 +96029,7 @@ ftc
 jUo
 qpD
 xZN
-xZN
+mbs
 irj
 tjF
 mpj
@@ -95353,7 +96037,7 @@ jns
 jns
 jns
 jns
-jns
+qgl
 jns
 jns
 epY
@@ -95550,29 +96234,29 @@ aHy
 oUj
 oUj
 aaQ
-bdj
+oMO
 pkJ
 nAt
-kWz
-dJD
-xip
+abP
+rIT
+eML
 xTE
-rOp
-lTt
-bkP
-abP
-abP
-bcF
-abP
+iME
+eML
+eML
+nXO
+xyU
+eML
+xyU
 blg
-uvR
-mws
-aAi
+biW
+pAK
+hPC
 bml
-blg
+oML
 rgf
 crU
-rmP
+cvo
 rmP
 awy
 rmP
@@ -95580,7 +96264,7 @@ bfZ
 rmP
 rmP
 rmP
-rmP
+ify
 pMY
 dZL
 mpj
@@ -95602,7 +96286,7 @@ ftc
 jUo
 qpD
 xZN
-xZN
+mbs
 kBk
 tjF
 tmP
@@ -95811,25 +96495,25 @@ cpx
 pkJ
 nAt
 abP
-mqy
-eML
-aWd
-eML
-eML
-aUz
+xxB
+pgO
+xTE
+djC
+cry
+oBE
 aqQ
-ajt
-eML
-boc
+mOP
+xyU
+kSp
 blg
-afS
-afS
-gxa
+wTb
 bml
-lzL
+mWT
+bml
+blg
 oDA
 cmQ
-rmP
+cvo
 rmP
 qPn
 qPn
@@ -95837,7 +96521,7 @@ bgd
 qPn
 qPn
 rmP
-rmP
+ify
 pMY
 dZL
 mpj
@@ -95859,7 +96543,7 @@ ftc
 lPx
 qpD
 xZN
-xZN
+mbs
 kBk
 sCO
 dZK
@@ -96064,29 +96748,29 @@ aAf
 cnZ
 oUj
 aaQ
-oMO
+cpx
 pkJ
 nAt
 abP
-rIT
-eML
-xTE
-iME
-eML
-eML
-nXO
-xyU
-eML
-xyU
+abP
+abP
+abP
 blg
-biW
-pAK
-hPC
+blg
+blg
+blg
+blg
+blg
+blg
+blg
+bvy
 bml
+bml
+eoo
 oML
 njq
 cmQ
-rmP
+cvo
 rmP
 rmP
 rmP
@@ -96094,7 +96778,7 @@ bfZ
 rmP
 rmP
 rmP
-rmP
+ify
 pMY
 dZL
 mpj
@@ -96116,7 +96800,7 @@ ldz
 sUr
 qpD
 ukz
-xZN
+mbs
 kBk
 wdP
 swq
@@ -96321,29 +97005,29 @@ aAf
 aAf
 aAf
 aaQ
-cpx
+uFw
 pkJ
-nAt
-abP
-xxB
-pgO
-xTE
-djC
-cry
-oBE
-aqQ
-eML
-xyU
-kSp
+fxJ
+wnj
+crt
+aUk
+aUk
 blg
-wTb
+bsX
 bml
+uiD
+aAi
+aAi
+blg
+wCK
 mWT
+fNE
 bml
-blg
+wLl
+oHs
 njq
 crU
-rmP
+cvo
 rmP
 rmP
 rmP
@@ -96351,7 +97035,7 @@ bge
 rmP
 rmP
 rmP
-rmP
+ify
 pMY
 dZL
 mpj
@@ -96373,7 +97057,7 @@ hDo
 bGA
 qpD
 qOB
-fUM
+wkn
 kBk
 swq
 swq
@@ -96578,29 +97262,29 @@ aAf
 cqo
 oUj
 aaQ
-cpx
-pkJ
+pdm
+xHh
+uBw
 nAt
-abP
-abP
-abP
-abP
+jpO
+rGi
+nlf
 blg
-blg
-blg
-blg
-blg
-blg
-blg
-blg
-bvy
+fKs
 bml
 bml
-eoo
-oML
+uep
+bmk
+blg
+jMa
+bml
+aRN
+eoG
+blg
+blg
 oDA
 crU
-rmP
+cvo
 rmP
 rmP
 rmP
@@ -96608,7 +97292,7 @@ bfZ
 rmP
 rmP
 rmP
-rmP
+ify
 pMY
 dZL
 mpj
@@ -96628,9 +97312,9 @@ izZ
 izZ
 izZ
 izZ
-qOB
-qOB
-qOB
+xZN
+xZN
+mbs
 kBk
 wdP
 epY
@@ -96835,29 +97519,29 @@ aAf
 cqY
 oUj
 aaQ
-uFw
+bdj
+cpx
 pkJ
-fxJ
-wnj
-crt
-aUk
-aUk
+nAt
+kJW
+iSD
+qVz
 blg
-bsX
+gsB
 bml
-uiD
-aAi
-aAi
+bml
+bml
+bml
 blg
-wCK
-mWT
-fNE
+mHD
 bml
-wLl
-oHs
-njq
+bml
+bml
+ybs
+lzL
+pMY
 crU
-rmP
+cvo
 rmP
 rmP
 rmP
@@ -96865,7 +97549,7 @@ bfZ
 eiK
 rmP
 rmP
-rmP
+ify
 pMY
 dZL
 mpj
@@ -96885,9 +97569,9 @@ kSu
 kSu
 kSu
 kSu
-qOB
-qOB
-qOB
+xZN
+xZN
+mbs
 kBk
 swq
 epY
@@ -97092,29 +97776,29 @@ aAf
 eMw
 oUj
 aaQ
-pdm
-xHh
-uBw
-nAt
-jpO
-rGi
-nlf
+cpx
+cpx
+pkJ
+fxJ
+qLf
+qLf
+qLf
 blg
-fKs
+vxz
+bev
+blz
+dHk
+bml
+blg
+bgX
 bml
 bml
-uep
-bmk
-blg
-jMa
-bml
-aRN
-eoG
-blg
-blg
-oDA
+enu
+uXY
+oHs
+pMY
 ctc
-rmP
+cvo
 eiK
 rmP
 rmP
@@ -97122,7 +97806,7 @@ bfZ
 rmP
 rmP
 rmP
-rmP
+ify
 pMY
 dZL
 mpj
@@ -97144,7 +97828,7 @@ xUU
 xQj
 qpD
 iva
-xZN
+mbs
 kBk
 wdP
 epY
@@ -97349,29 +98033,29 @@ aHy
 oUj
 oUj
 aLD
-bdj
-cpx
-pkJ
-nAt
-kJW
-iSD
-qVz
+qRe
+aic
+xHh
+fgp
+fgp
+uBw
+vJu
 blg
-gsB
-bml
-bml
-bml
-bml
+bux
+okl
+okl
 blg
-mHD
-bml
-bml
-bml
-ybs
-lzL
-oDA
+bpu
+blg
+blg
+bpu
+bpu
+blg
+okl
+blg
+pMY
 crU
-rmP
+cvo
 rmP
 rmP
 rmP
@@ -97379,7 +98063,7 @@ bge
 rmP
 rmP
 rmP
-rmP
+ify
 pMY
 dZL
 mpj
@@ -97401,7 +98085,7 @@ hDo
 bGA
 qpD
 jOi
-xZN
+mbs
 kBk
 wdP
 epY
@@ -97608,27 +98292,27 @@ oUj
 aaQ
 cpx
 cpx
+cpx
+cpx
+cpx
 pkJ
-fxJ
-qLf
-tcy
-kIQ
-blg
-vxz
-bev
-blz
-dHk
-bml
-blg
-bgX
-bml
-bml
-enu
-uXY
-oHs
-njq
+vJu
+pMY
+hmz
+hmz
+hmz
+hmz
+hmz
+hmz
+hmz
+hmz
+hmz
+hmz
+hmz
+eHm
+eHm
 crU
-rmP
+cvo
 rmP
 rmP
 rmP
@@ -97636,7 +98320,7 @@ bfZ
 rmP
 rmP
 rmP
-rmP
+ify
 pMY
 dZL
 mpj
@@ -97658,7 +98342,7 @@ xZN
 xZN
 xZN
 jOi
-xZN
+mbs
 kBk
 swq
 epY
@@ -97863,29 +98547,29 @@ aAf
 bcN
 oUj
 aaQ
-qRe
-aic
+cpx
+cpx
+cpx
+cpx
+cpx
 xHh
 fgp
-fgp
-fgp
-fgp
-blg
-bux
-okl
-okl
-blg
-bpu
-blg
-blg
-bpu
-bpu
-blg
-okl
-blg
-njq
+iVI
+knn
+pch
+pch
+pch
+pch
+knn
+pch
+wUg
+wUg
+pch
+knn
+knn
+ycj
 crU
-rmP
+cvo
 rmP
 rmP
 rmP
@@ -97893,7 +98577,7 @@ bfZ
 eiK
 rmP
 eiK
-rmP
+ify
 pMY
 dZL
 mpj
@@ -97915,7 +98599,7 @@ xZN
 iva
 iva
 jOi
-xZN
+mbs
 kBk
 swq
 epY
@@ -98133,16 +98817,16 @@ rHX
 rHX
 rHX
 rHX
-cpL
 rHX
 rHX
 rHX
 rHX
 rHX
 rHX
-njq
+rHX
+pMY
 crU
-rmP
+cvo
 rmP
 aEr
 rmP
@@ -98150,7 +98834,7 @@ bfZ
 rmP
 rmP
 eiK
-rmP
+ify
 pMY
 dZL
 mpj
@@ -98172,7 +98856,7 @@ jOi
 ooV
 tJp
 jOi
-xZN
+mbs
 bgH
 wdP
 epY
@@ -98386,20 +99070,20 @@ cpx
 cpx
 cpx
 kpu
-kcR
-rHX
-rHX
-rDk
-uQt
 rHX
 rHX
 rHX
 rHX
-kcR
+cpL
+rHX
+rHX
+rHX
+rHX
+rHX
 rHX
 oDA
-sCz
-rmP
+crU
+cvo
 rmP
 rmP
 rmP
@@ -98407,7 +99091,7 @@ bfZ
 rmP
 rmP
 rmP
-rmP
+ify
 pMY
 dZL
 mpj
@@ -98429,7 +99113,7 @@ bxl
 vvX
 xiA
 vVc
-xZN
+mbs
 kBk
 kbY
 epY
@@ -98643,20 +99327,20 @@ qzO
 ctb
 qzO
 sPk
-blf
-jsw
-aWq
-xbQ
-xbQ
-aWq
-brc
-hQY
-saf
-aAl
+kcR
 rHX
-pMY
+rHX
+rDk
+uQt
+rHX
+rHX
+rHX
+rHX
+kcR
+rHX
+oDA
 crU
-rmP
+cvo
 eiK
 rmP
 rmP
@@ -98664,7 +99348,7 @@ bgf
 rmP
 acq
 rmP
-rmP
+ify
 pMY
 dZL
 mpj
@@ -98686,7 +99370,7 @@ jOi
 kzt
 kzt
 kzt
-xZN
+mbs
 bGz
 wdP
 gEi
@@ -98900,20 +99584,20 @@ vnv
 rHX
 rHX
 rHX
-qhO
-cvT
+blf
+jsw
+aWq
 xbQ
 xbQ
-xbQ
-vyC
-cwa
-sop
-cmS
+aWq
+brc
+hQY
+saf
+aAl
 rHX
-rHX
-pMY
+oDA
 crU
-rmP
+cvo
 rmP
 rmP
 rmP
@@ -98921,7 +99605,7 @@ bfZ
 rmP
 acq
 rmP
-rmP
+ify
 pMY
 dZL
 mpj
@@ -98943,7 +99627,7 @@ qIh
 xZN
 xZN
 xZN
-xZN
+mbs
 cKl
 gTC
 gEi
@@ -99101,7 +99785,7 @@ pJY
 fzu
 aMN
 azh
-wCN
+aIW
 oVW
 aNZ
 aJa
@@ -99157,20 +99841,20 @@ kpu
 fhy
 iEh
 vnv
-ciS
-dJV
+qhO
+cvT
 xbQ
 xbQ
 xbQ
-xbQ
-xbQ
-gGn
+vyC
+cwa
+sop
+cmS
 rHX
-cvu
 rHX
 pMY
 crU
-rmP
+cvo
 rmP
 rmP
 rmP
@@ -99178,7 +99862,7 @@ bfZ
 rmP
 rmP
 rmP
-rmP
+ify
 pMY
 dZL
 mpj
@@ -99200,7 +99884,7 @@ xZN
 xZN
 jOi
 xZN
-xZN
+mbs
 cKl
 ctF
 epY
@@ -99414,20 +100098,20 @@ sPk
 eBH
 cyJ
 jjJ
-qpM
-bhe
-cvT
+ciS
+dJV
 xbQ
 xbQ
 xbQ
-dRJ
-ths
+xbQ
+xbQ
+gGn
 rHX
-rHX
+cvu
 rHX
 njq
 crU
-rmP
+cvo
 rmP
 rmP
 rmP
@@ -99435,7 +100119,7 @@ bfZ
 rmP
 eiK
 rmP
-rmP
+ify
 pMY
 dZL
 mpj
@@ -99457,7 +100141,7 @@ qIh
 xZN
 xZN
 xZN
-xZN
+mbs
 cKl
 reb
 epY
@@ -99671,20 +100355,20 @@ haX
 iXx
 cpx
 kpu
+qpM
+bhe
+cvT
+xbQ
+xbQ
+xbQ
+dRJ
+ths
 rHX
-xXf
-qSq
-xbQ
-xbQ
-xbQ
-cwa
-jtg
 rHX
-saf
 rHX
 njq
 crU
-rmP
+cvo
 rmP
 rmP
 rmP
@@ -99692,7 +100376,7 @@ bge
 rmP
 rmP
 rmP
-rmP
+ify
 pMY
 dZL
 mpj
@@ -99707,7 +100391,7 @@ kVQ
 qOh
 abP
 jUo
-qpD
+dYy
 kSu
 kSu
 kSu
@@ -99859,7 +100543,7 @@ beW
 oJz
 wHr
 azh
-aIA
+aIF
 aIF
 aJs
 aIF
@@ -99928,20 +100612,20 @@ cpx
 cpx
 cpx
 kpu
-cvu
-xXf
-oMQ
-xbQ
-xbQ
-xbQ
-xbQ
-aWq
-brc
 rHX
+xXf
+qSq
+xbQ
+xbQ
+xbQ
+cwa
+jtg
+rHX
+saf
 rHX
 pMY
 crU
-rmP
+cvo
 rmP
 rmP
 rmP
@@ -99949,7 +100633,7 @@ bfZ
 rmP
 rmP
 rmP
-rmP
+ify
 pMY
 dZL
 mpj
@@ -100185,20 +100869,20 @@ aic
 kJP
 cpx
 kpu
-rHX
-cvp
+cvu
+xXf
+oMQ
 xbQ
 xbQ
 xbQ
 xbQ
-xbQ
-cvP
-cwa
+aWq
+brc
 rHX
 rHX
 pMY
 crU
-rmP
+cvo
 rmP
 rmP
 rmP
@@ -100206,7 +100890,7 @@ bfZ
 rmP
 rmP
 rmP
-rmP
+ify
 pMY
 dZL
 mpj
@@ -100379,7 +101063,7 @@ aJt
 mXL
 aIF
 azh
-qgl
+ims
 voA
 aLV
 voA
@@ -100443,19 +101127,19 @@ qzO
 vtf
 kpu
 rHX
-rDk
-ycm
+cvp
+xbQ
+xbQ
+xbQ
+xbQ
 xbQ
 cvP
-xbQ
-xbQ
 cwa
-hQY
-gOS
+rHX
 rHX
 pMY
 crU
-rmP
+cvo
 eiK
 rmP
 eiK
@@ -100463,7 +101147,7 @@ bgb
 rmP
 rmP
 rmP
-rmP
+ify
 pMY
 dZL
 aae
@@ -100699,20 +101383,20 @@ kyH
 kyH
 eBH
 kpu
-cvq
-uol
-xbQ
+rHX
+rDk
+ycm
 xbQ
 cvP
-cvW
+xbQ
 xbQ
 cwa
-sop
-cmS
+hQY
+gOS
 rHX
 oDA
 crU
-rmP
+cvo
 rmP
 rmP
 rmP
@@ -100720,7 +101404,7 @@ bgc
 rmP
 eiK
 rmP
-rmP
+ify
 pMY
 dZL
 aae
@@ -100956,20 +101640,20 @@ vRu
 cty
 eBH
 kpu
-rUL
-cvQ
+cvq
+uol
+xbQ
+xbQ
 cvP
+cvW
 xbQ
-xbQ
-beP
-xbQ
-xbQ
-brc
-xXf
+cwa
+sop
+cmS
 rHX
 oDA
 nAt
-rmP
+cvo
 rmP
 rmP
 rmP
@@ -100977,7 +101661,7 @@ bfZ
 rmP
 rmP
 rmP
-rmP
+ify
 pMY
 dZL
 aae
@@ -101213,20 +101897,20 @@ crz
 kyH
 eBH
 kpu
-cvr
+rUL
 cvQ
+cvP
 xbQ
 xbQ
-nKq
-vjy
-nKq
+beP
 xbQ
-cwa
+xbQ
+brc
 xXf
 rHX
 oDA
 nAt
-rmP
+cvo
 rmP
 rmP
 rmP
@@ -101234,7 +101918,7 @@ bfZ
 rmP
 agI
 rmP
-rmP
+ify
 pMY
 dZL
 aae
@@ -101470,20 +102154,20 @@ csj
 kyH
 eBH
 kpu
-cvs
+cvr
 cvQ
 xbQ
 xbQ
-xbQ
 nKq
-xbQ
+vjy
+nKq
 xbQ
 cwa
 xXf
-rwK
+rHX
 oDA
 crU
-rmP
+cvo
 rmP
 acq
 rmP
@@ -101491,7 +102175,7 @@ bfZ
 rmP
 rmP
 rmP
-rmP
+ify
 pMY
 dZL
 aae
@@ -101727,20 +102411,20 @@ kyH
 kyH
 eBH
 kpu
-cvu
+cvs
 cvQ
 xbQ
-cvP
 xbQ
-cvP
 xbQ
-fQi
-bPk
+nKq
+xbQ
+xbQ
+cwa
 xXf
-kcR
+rwK
 oDA
 crU
-rmP
+cvo
 rmP
 rmP
 rmP
@@ -101748,7 +102432,7 @@ bfZ
 rmP
 rmP
 eiK
-rmP
+ify
 pMY
 dZL
 aae
@@ -101984,20 +102668,20 @@ fhy
 iEh
 iXx
 kpu
-rHX
+cvu
 cvQ
 xbQ
+cvP
 xbQ
+cvP
 xbQ
-xbQ
-xbQ
-xbQ
-cwa
+fQi
+bPk
 xXf
-rHX
+kcR
 oDA
 crU
-rmP
+cvo
 rmP
 eiK
 rmP
@@ -102005,7 +102689,7 @@ bfZ
 rmP
 eiK
 rmP
-rmP
+ify
 pMY
 dZL
 aae
@@ -102242,19 +102926,19 @@ qzO
 qzO
 sPk
 rHX
-rHX
-lah
-cvT
+cvQ
 xbQ
 xbQ
 xbQ
 xbQ
-mvM
-pAx
+xbQ
+xbQ
+cwa
+xXf
 rHX
 oDA
 cmQ
-rmP
+cvo
 rmP
 rmP
 rmP
@@ -102262,7 +102946,7 @@ bga
 rmP
 rmP
 rmP
-rmP
+ify
 pMY
 dZL
 aae
@@ -102500,18 +103184,18 @@ cqk
 vnv
 rHX
 rHX
-xXf
-pxq
-cvP
+lah
+cvT
 xbQ
 xbQ
-bPk
-ths
-rHX
+xbQ
+xbQ
+mvM
+pAx
 rHX
 oDA
 cmQ
-rmP
+cvo
 rmP
 rmP
 rmP
@@ -102519,7 +103203,7 @@ bfZ
 rmP
 rmP
 rmP
-rmP
+ify
 pMY
 dZL
 aae
@@ -102756,19 +103440,19 @@ qRe
 cpx
 xFh
 vnv
-grn
-xVV
-els
-els
-sli
-cvT
-cwa
 rHX
-loG
+xXf
+pxq
+cvP
+xbQ
+xbQ
+bPk
+ths
+rHX
 rHX
 njq
 vjK
-rmP
+cvo
 eiK
 rmP
 rmP
@@ -102776,7 +103460,7 @@ bfZ
 rmP
 rmP
 rmP
-rmP
+ify
 pMY
 agk
 agk
@@ -103013,19 +103697,19 @@ cpx
 cpx
 alm
 kpu
-saf
-rHX
-rHX
-rHX
+grn
 xVV
-jNG
 els
-oqe
-xwb
-saf
+els
+sli
+cvT
+cwa
+rHX
+loG
+rHX
 njq
 crU
-rmP
+cvo
 rmP
 rmP
 rmP
@@ -103033,7 +103717,7 @@ bfZ
 rmP
 rmP
 rmP
-rmP
+ify
 pMY
 agk
 abr
@@ -103270,19 +103954,19 @@ qIk
 tBN
 qzO
 sPk
-rHX
-rHX
-kcR
-rHX
+saf
 rHX
 rHX
 rHX
-rHX
-nfu
-rHX
+xVV
+jNG
+els
+oqe
+xwb
+saf
 njq
 cmQ
-rmP
+cvo
 rmP
 rmP
 rmP
@@ -103290,7 +103974,7 @@ bfZ
 eiK
 rmP
 eiK
-rmP
+ify
 pMY
 agk
 abC
@@ -103539,7 +104223,7 @@ rHX
 rHX
 oDA
 cmQ
-rmP
+cvo
 rmP
 rmP
 rmP
@@ -103547,7 +104231,7 @@ bfZ
 eiK
 rmP
 eiK
-rmP
+ify
 pMY
 agk
 abD
@@ -103796,7 +104480,7 @@ rHX
 rwK
 oDA
 cmQ
-eiK
+cvo
 rmP
 aeY
 rmP
@@ -103804,7 +104488,7 @@ bfZ
 rmP
 rmP
 eiK
-rmP
+ify
 pMY
 agk
 abC
@@ -104053,7 +104737,7 @@ aXL
 rHX
 oDA
 crU
-rmP
+cvo
 rmP
 rmP
 rmP
@@ -104061,7 +104745,7 @@ bfZ
 rmP
 rmP
 eiK
-rmP
+ify
 pMY
 agk
 abC
@@ -104310,7 +104994,7 @@ rHX
 btN
 oDA
 crU
-rmP
+cvo
 rmP
 rmP
 rmP
@@ -104318,7 +105002,7 @@ bge
 acq
 rmP
 rmP
-rmP
+ify
 pMY
 agk
 acS
@@ -104567,7 +105251,7 @@ lLH
 rHX
 oDA
 cmQ
-rmP
+cvo
 rmP
 rmP
 rmP
@@ -104575,7 +105259,7 @@ bfZ
 rmP
 rmP
 rmP
-rmP
+ify
 pMY
 agk
 abF
@@ -104824,7 +105508,7 @@ rHX
 rHX
 njq
 cmQ
-rmP
+cvo
 eiK
 rmP
 rmP
@@ -104832,7 +105516,7 @@ bfZ
 rmP
 rmP
 rmP
-rmP
+ify
 pMY
 agk
 abL
@@ -104930,7 +105614,7 @@ qzL
 wjW
 tbY
 aWY
-eXI
+xoc
 adi
 vLZ
 vLZ
@@ -105081,7 +105765,7 @@ hhs
 rHX
 njq
 crU
-rmP
+cvo
 rmP
 rmP
 rmP
@@ -105089,7 +105773,7 @@ bfZ
 eiK
 rmP
 rmP
-rmP
+ify
 pMY
 agk
 abQ
@@ -105338,7 +106022,7 @@ rHX
 rHX
 njq
 crU
-rmP
+cvo
 rmP
 rmP
 rmP
@@ -105346,7 +106030,7 @@ bfZ
 rmP
 rmP
 rmP
-rmP
+ify
 pMY
 agk
 acb
@@ -105582,9 +106266,9 @@ xFh
 iEh
 iEh
 iEh
-iEh
-jpT
-nBP
+iXx
+usJ
+bDK
 iEr
 iEr
 iEr
@@ -105595,7 +106279,7 @@ aXf
 alv
 oDA
 crU
-rmP
+cvo
 rmP
 eiK
 rmP
@@ -105603,7 +106287,7 @@ bfZ
 rmP
 rmP
 rmP
-rmP
+ify
 pMY
 agk
 aci
@@ -105852,7 +106536,7 @@ ctV
 hYk
 hYk
 crU
-rmP
+cvo
 rmP
 rmP
 rmP
@@ -105860,7 +106544,7 @@ bga
 rmP
 rmP
 rmP
-rmP
+ify
 pMY
 vJu
 vJu
@@ -106094,7 +106778,7 @@ cpx
 cpx
 kJP
 cpx
-cpx
+qRe
 cpx
 ylE
 pch
@@ -106109,7 +106793,7 @@ lDH
 oCH
 aSy
 wHm
-rmP
+cvo
 rmP
 rmP
 rmP
@@ -106117,7 +106801,7 @@ bge
 rmP
 rmP
 eiK
-rmP
+ify
 iVI
 aSy
 sVD
@@ -106348,7 +107032,7 @@ xPu
 xPu
 fUe
 cpx
-cpx
+qRe
 cpx
 cpx
 cpx
@@ -107121,7 +107805,7 @@ iRm
 qRe
 cpx
 aAk
-cpx
+qRe
 cpx
 cpx
 aPS
@@ -107137,7 +107821,7 @@ qLf
 qLf
 fkb
 wnj
-rmP
+cvo
 rmP
 rmP
 rmP
@@ -107145,7 +107829,7 @@ bgc
 rmP
 rmP
 rmP
-rmP
+ify
 jPD
 fkb
 qLf
@@ -107374,10 +108058,10 @@ fgp
 fgp
 uBw
 aBP
-eVx
-pxv
-pxv
-axy
+wyN
+cpx
+cpx
+cpx
 cpx
 cpx
 dny
@@ -107394,7 +108078,7 @@ beM
 agk
 esK
 nAt
-rmP
+cvo
 acq
 rmP
 rmP
@@ -107630,11 +108314,11 @@ cpx
 cpx
 cpx
 pkJ
-esK
-buU
-muJ
-rhP
-dip
+dzB
+tQM
+qRe
+cpx
+cpx
 aPS
 dYH
 upZ
@@ -107651,7 +108335,7 @@ beU
 bfw
 esK
 nAt
-rmP
+cvo
 rmP
 rmP
 rmP
@@ -107659,7 +108343,7 @@ bfZ
 rmP
 rmP
 eiK
-rmP
+ify
 pMY
 nAt
 ejQ
@@ -107887,9 +108571,9 @@ cpx
 cpx
 cpx
 pkJ
-esK
-cmQ
-vdc
+eVx
+wTj
+oUk
 pxv
 pxv
 dYH
@@ -107908,7 +108592,7 @@ beU
 bfw
 esK
 nAt
-rmP
+cvo
 rmP
 rmP
 rmP
@@ -107916,7 +108600,7 @@ bfZ
 rmP
 rmP
 rmP
-rmP
+ify
 pMY
 nAt
 cvo
@@ -108055,12 +108739,12 @@ geJ
 cVp
 oov
 vnY
-pMm
-pMm
-pMm
-pMm
-pMm
-pMm
+ddg
+ddg
+ddg
+ddg
+ddg
+ddg
 rwJ
 eTH
 eLj
@@ -108165,7 +108849,7 @@ gzr
 agk
 vJu
 nAt
-rmP
+cvo
 rmP
 bdT
 rmP
@@ -108173,7 +108857,7 @@ bfZ
 rmP
 rmP
 rmP
-rmP
+ify
 pMY
 nAt
 cwU
@@ -108311,7 +108995,7 @@ ejj
 qSh
 fhg
 oov
-hcm
+oov
 pMm
 pMm
 pMm
@@ -108422,7 +109106,7 @@ afS
 bfx
 vJu
 nAt
-rmP
+cvo
 rmP
 eiK
 rmP
@@ -108430,7 +109114,7 @@ bfZ
 rmP
 rmP
 rmP
-rmP
+ify
 pMY
 nAt
 cvo
@@ -108568,17 +109252,17 @@ iMB
 xBE
 xYU
 oov
-hcm
-pMm
-pMm
-pMm
-pMm
-pMm
-uKu
+oov
+jtW
+jtW
+jtW
+jtW
+jtW
+add
 oFy
 aOm
-sXS
-aAY
+njC
+sCz
 wNf
 gCf
 aFP
@@ -108679,7 +109363,7 @@ afS
 agk
 vJu
 nAt
-rmP
+cvo
 rmP
 rmP
 rmP
@@ -108687,7 +109371,7 @@ bfZ
 rmP
 rmP
 rmP
-rmP
+ify
 iVI
 uKE
 cvo
@@ -108936,7 +109620,7 @@ beU
 agk
 vJu
 nAt
-rmP
+cvo
 rmP
 rmP
 rmP
@@ -109052,34 +109736,34 @@ jSl
 dKo
 dKo
 dKo
-dKo
-dKo
-dKo
-dKo
-dKo
-dKo
-dKo
-dKo
-dKo
-dKo
-dKo
-kku
-feX
-eRE
+gpP
+gpP
+gpP
+gpP
+gpP
+gpP
+gpP
+gpP
+gpP
+gpP
+gpP
+mTD
+fZL
+sYk
 rsE
-oZy
+rQg
 gpP
 bhq
 mBz
 avS
-avS
+eeK
 hKH
 gpP
-tzr
+xff
 dxo
-oov
-oov
-oov
+ddg
+ddg
+ddg
 oov
 dYK
 hcm
@@ -109193,7 +109877,7 @@ beU
 agk
 vJu
 nAt
-rmP
+cvo
 rmP
 rmP
 aeY
@@ -109309,22 +109993,22 @@ qVl
 dKo
 dKo
 dKo
-dKo
-dKo
-dKo
-dKo
-dKo
-dKo
-dKo
-dKo
-dKo
-dKo
-dKo
+owX
+owX
+owX
+owX
+owX
+owX
+owX
+owX
+owX
+owX
+owX
 kku
-feX
+wvR
 eRE
 uEv
-oZy
+mZR
 owX
 mJh
 avS
@@ -109332,12 +110016,12 @@ uGX
 avS
 nmR
 owX
-tzr
-dxo
-oov
-oov
-oov
-oov
+elA
+dPF
+pMm
+pMm
+pMm
+dYK
 upD
 dYK
 xOh
@@ -109450,7 +110134,7 @@ agk
 agk
 esK
 cje
-rmP
+cvo
 rmP
 rmP
 rmP
@@ -109571,16 +110255,16 @@ dKo
 dKo
 dKo
 dKo
-dKo
-dKo
+ukW
+ukW
 wsm
-dKo
-dKo
-dKo
-kku
+ukW
+ukW
+ukW
+nQs
 feX
 rim
-rsE
+mqx
 oZy
 ukW
 mJh
@@ -109588,13 +110272,13 @@ avS
 uGX
 dTP
 nmR
-owX
+ukW
 bGa
 vkM
-rmP
-rmP
-rmP
-rmP
+sLz
+dnw
+wNn
+eiK
 eiK
 nlf
 pMY
@@ -109707,7 +110391,7 @@ agk
 ctV
 esK
 nAt
-rmP
+cvo
 eiK
 rmP
 rmP
@@ -109715,7 +110399,7 @@ bgf
 rmP
 rmP
 rmP
-rmP
+ify
 jPD
 wnj
 cwU
@@ -109964,7 +110648,7 @@ agk
 ctV
 esK
 nAt
-rmP
+cvo
 rmP
 rmP
 rmP
@@ -109972,7 +110656,7 @@ bfZ
 rmP
 rmP
 acq
-rmP
+ify
 pMY
 nAt
 cvo
@@ -110221,7 +110905,7 @@ agk
 esK
 esK
 nAt
-rmP
+cvo
 rmP
 rmP
 rmP
@@ -110229,7 +110913,7 @@ bfZ
 rmP
 rmP
 acq
-rmP
+ify
 pMY
 nAt
 dQT
@@ -110407,7 +111091,7 @@ cpx
 cpx
 pkJ
 nAt
-quQ
+oLp
 kdL
 aOn
 kdL
@@ -110478,7 +111162,7 @@ agk
 bfz
 esK
 nAt
-rmP
+cvo
 rmP
 rmP
 rmP
@@ -110486,7 +111170,7 @@ bfZ
 rmP
 rmP
 acq
-rmP
+ify
 pMY
 fxJ
 mgd
@@ -110632,7 +111316,7 @@ cpx
 cpx
 cpx
 cpx
-cpx
+pdm
 cpx
 cpx
 cpx
@@ -110735,7 +111419,7 @@ agk
 esK
 vJu
 nAt
-rmP
+cvo
 rmP
 rmP
 rmP
@@ -110743,7 +111427,7 @@ bfZ
 rmP
 rmP
 rmP
-rmP
+ify
 pMY
 sIa
 fgp
@@ -110913,7 +111597,7 @@ cpx
 cpx
 cpx
 cpx
-cpx
+pdm
 cpx
 cpx
 cpx
@@ -110992,7 +111676,7 @@ vJu
 vJu
 vJu
 nAt
-rmP
+cvo
 eiK
 rmP
 rmP
@@ -111000,7 +111684,7 @@ bgg
 rmP
 rmP
 rmP
-rmP
+ify
 pMY
 dZL
 cpx
@@ -111187,7 +111871,7 @@ uWg
 kdL
 kdL
 kdL
-cvo
+rmP
 rmP
 tkv
 aQq
@@ -111249,7 +111933,7 @@ esK
 vJu
 esK
 nAt
-rmP
+cvo
 rmP
 rmP
 rmP
@@ -111257,7 +111941,7 @@ bfZ
 rmP
 eiK
 rmP
-rmP
+ify
 pMY
 dZL
 cpx
@@ -111438,13 +112122,13 @@ nAt
 cvo
 xPu
 pnc
-aDa
+oPW
 uWg
 xPu
 xPu
 xPu
 xPu
-kgd
+rmP
 rmP
 tkv
 njq
@@ -111506,7 +112190,7 @@ agk
 agk
 vJu
 nAt
-rmP
+cvo
 rmP
 rmP
 rmP
@@ -111514,7 +112198,7 @@ bfZ
 rmP
 rmP
 rmP
-rmP
+ify
 pMY
 dZL
 cpx
@@ -111670,7 +112354,7 @@ cpx
 cpx
 cpx
 cpx
-cpx
+pdm
 cpx
 cpx
 cpx
@@ -111696,12 +112380,12 @@ cvo
 xPu
 xPu
 xPu
-mzW
+xPu
 xPu
 sLz
 sLz
-xPu
-nQe
+sLz
+rFG
 rmP
 tkv
 pCy
@@ -111763,7 +112447,7 @@ afS
 bfA
 vJu
 nAt
-rmP
+cvo
 rmP
 rmP
 rmP
@@ -111771,7 +112455,7 @@ bgg
 rmP
 rmP
 rmP
-rmP
+ify
 pMY
 dZL
 cpx
@@ -111937,7 +112621,7 @@ cpx
 cpx
 cpx
 cpx
-cpx
+pdm
 cpx
 cpx
 cpx
@@ -112020,7 +112704,7 @@ afS
 bfA
 vJu
 nAt
-rmP
+cvo
 rmP
 rmP
 rmP
@@ -112028,7 +112712,7 @@ bfZ
 rmP
 rmP
 rmP
-rmP
+ify
 pMY
 dZL
 pdm
@@ -112266,7 +112950,7 @@ aqF
 aDt
 nAt
 cvo
-xPu
+ify
 agk
 beA
 afS
@@ -112277,7 +112961,7 @@ afS
 bfB
 vJu
 nAt
-rmP
+cvo
 rmP
 rmP
 rmP
@@ -112285,7 +112969,7 @@ bfZ
 rmP
 rmP
 eiK
-rmP
+ify
 pMY
 dZL
 cpx
@@ -112523,7 +113207,7 @@ aqF
 aDt
 nAt
 cvo
-xPu
+ify
 agk
 qdz
 afS
@@ -112534,7 +113218,7 @@ afS
 bfA
 esK
 nAt
-rmP
+cvo
 rmP
 eiK
 eiK
@@ -112542,7 +113226,7 @@ bfZ
 rmP
 rmP
 eiK
-rmP
+ify
 pMY
 dZL
 aoN
@@ -112647,14 +113331,14 @@ wPK
 wPK
 aXt
 upC
-cHX
-dKo
-oPh
-dKo
-oPh
-dKo
-oPh
-dKo
+rDf
+ukW
+uxL
+ukW
+uxL
+ukW
+uxL
+ukW
 eLd
 cvN
 vVo
@@ -112780,7 +113464,7 @@ aqF
 aDt
 nAt
 cvo
-xPu
+ify
 agk
 afS
 qAs
@@ -112791,7 +113475,7 @@ agk
 agk
 esK
 nAt
-rmP
+cvo
 rmP
 rmP
 rmP
@@ -112799,7 +113483,7 @@ bfZ
 rmP
 rmP
 rmP
-rmP
+ify
 pMY
 dZL
 cpx
@@ -112946,7 +113630,7 @@ cpx
 cpx
 cpx
 cpx
-cpx
+pdm
 cpx
 cpx
 cpx
@@ -113037,7 +113721,7 @@ aKP
 gpS
 nAt
 cvo
-xPu
+ahQ
 agk
 beC
 afS
@@ -113048,7 +113732,7 @@ esK
 esK
 vJu
 nAt
-rmP
+cvo
 rmP
 rmP
 rmP
@@ -113056,7 +113740,7 @@ bga
 rmP
 rmP
 rmP
-rmP
+ify
 pMY
 dZL
 cpx
@@ -113293,8 +113977,8 @@ asX
 aKP
 kpl
 nAt
-cvo
-xPu
+qNL
+ahQ
 agk
 beC
 afS
@@ -113305,7 +113989,7 @@ vJu
 esK
 vJu
 nAt
-rmP
+cvo
 rmP
 rmP
 rmP
@@ -113313,7 +113997,7 @@ bfZ
 rmP
 rmP
 rmP
-rmP
+ify
 pMY
 dZL
 aoN
@@ -113472,8 +114156,8 @@ cpx
 cpx
 cpx
 cpx
-cpx
-cpx
+pdm
+pdm
 cpx
 cpx
 cpx
@@ -113550,8 +114234,8 @@ asX
 rFs
 ctV
 nAt
-cvo
-xPu
+muJ
+ahQ
 agk
 afS
 afS
@@ -113562,7 +114246,7 @@ agk
 agk
 vJu
 cje
-rmP
+cvo
 rmP
 rmP
 rmP
@@ -113570,7 +114254,7 @@ bge
 rmP
 rmP
 rmP
-rmP
+ify
 pMY
 dZL
 aoN
@@ -113764,7 +114448,7 @@ euN
 aQN
 afz
 ctq
-cvo
+oLp
 kdL
 kdL
 kdL
@@ -113807,8 +114491,8 @@ asX
 nwW
 oqY
 nAt
-cvo
-xPu
+muJ
+nlf
 agk
 afS
 afS
@@ -113819,7 +114503,7 @@ afS
 bfA
 vJu
 nAt
-rmP
+cvo
 rmP
 rmP
 acq
@@ -113827,7 +114511,7 @@ bfZ
 rmP
 rmP
 rmP
-rmP
+ify
 pMY
 dZL
 cpx
@@ -114064,8 +114748,8 @@ beT
 aKP
 wwj
 nAt
-cvo
-xPu
+muJ
+nlf
 agk
 beE
 afS
@@ -114076,7 +114760,7 @@ afS
 bfB
 vJu
 nAt
-rmP
+cvo
 rmP
 agI
 rmP
@@ -114084,7 +114768,7 @@ bfZ
 rmP
 rmP
 rmP
-rmP
+ify
 pMY
 dZL
 cpx
@@ -114307,7 +114991,7 @@ aqQ
 aqQ
 aqQ
 cpx
-cpx
+qRe
 cpx
 cpx
 aKP
@@ -114321,8 +115005,8 @@ nhH
 aKP
 gpS
 nAt
-cvo
-xPu
+muJ
+nlf
 agk
 beE
 afS
@@ -114333,7 +115017,7 @@ afS
 bfB
 vJu
 nAt
-rmP
+cvo
 rmP
 rmP
 rmP
@@ -114341,7 +115025,7 @@ bga
 rmP
 rmP
 eiK
-rmP
+ify
 pMY
 dZL
 cpx
@@ -114578,8 +115262,8 @@ beT
 aKP
 alY
 nAt
-cvo
-xPu
+muJ
+ahQ
 agk
 afS
 afS
@@ -114590,7 +115274,7 @@ afS
 bfA
 vJu
 nAt
-rmP
+cvo
 eiK
 rmP
 rmP
@@ -114598,7 +115282,7 @@ bge
 rmP
 rmP
 rmP
-rmP
+ify
 pMY
 dZL
 cpx
@@ -114746,6 +115430,7 @@ kbA
 cpx
 cpx
 cpx
+pdm
 cpx
 cpx
 cpx
@@ -114761,8 +115446,7 @@ cpx
 cpx
 cpx
 cpx
-cpx
-cpx
+pdm
 cpx
 cpx
 cpx
@@ -114835,8 +115519,8 @@ bgI
 rFs
 kpl
 nAt
-cvo
-xPu
+aea
+ahQ
 agk
 beF
 bho
@@ -114847,7 +115531,7 @@ agk
 agk
 vJu
 nAt
-rmP
+cvo
 rmP
 rmP
 rmP
@@ -114855,7 +115539,7 @@ bfZ
 rmP
 rmP
 eiK
-rmP
+ify
 pMY
 dZL
 cpx
@@ -115019,7 +115703,7 @@ cpx
 cpx
 cpx
 cpx
-cpx
+pdm
 cpx
 cpx
 cpx
@@ -115092,8 +115776,8 @@ asX
 nwW
 ctV
 nAt
-cvo
-xPu
+dpL
+ify
 agk
 afS
 beS
@@ -115104,7 +115788,7 @@ vJu
 vJu
 vJu
 nAt
-rmP
+cvo
 rmP
 rmP
 rmP
@@ -115112,7 +115796,7 @@ bfZ
 rmP
 rmP
 rmP
-rmP
+ify
 pMY
 dZL
 cpx
@@ -115336,7 +116020,7 @@ aUz
 aqQ
 cpx
 cpx
-cpx
+qRe
 cpx
 aKP
 sfy
@@ -115349,8 +116033,8 @@ asX
 aKP
 oqY
 nAt
-cvo
-xPu
+dpL
+ify
 afC
 afS
 afS
@@ -115361,7 +116045,7 @@ vJu
 vJu
 vJu
 nAt
-rmP
+cvo
 rmP
 rmP
 rmP
@@ -115369,7 +116053,7 @@ bfZ
 rmP
 rmP
 rmP
-rmP
+ify
 pMY
 dZL
 cpx
@@ -115606,8 +116290,8 @@ aKP
 aKP
 qiy
 nAt
-cvo
-xPu
+dpL
+ify
 agk
 agk
 bep
@@ -115618,7 +116302,7 @@ knn
 knn
 ycj
 nAt
-rmP
+cvo
 rmP
 rmP
 eiK
@@ -115626,7 +116310,7 @@ bfZ
 rmP
 rmP
 rmP
-rmP
+ify
 pMY
 dZL
 cpx
@@ -115703,7 +116387,7 @@ lTe
 lTe
 lTe
 aav
-lTe
+abO
 lTe
 lTe
 afn
@@ -115758,7 +116442,7 @@ aae
 aae
 cpx
 cpx
-cpx
+pdm
 cpx
 pkJ
 nAt
@@ -115863,19 +116547,19 @@ asX
 sNP
 tRi
 nAt
-cvo
-xPu
+dpL
+pgy
 kdL
 ufd
-kdL
-kdL
-kdL
-kdL
-kdL
+auZ
+auZ
+auZ
+auZ
+auZ
 kdL
 pMY
 nAt
-rmP
+cvo
 eiK
 rmP
 rmP
@@ -115883,7 +116567,7 @@ bfZ
 rmP
 rmP
 rmP
-rmP
+ify
 pMY
 dZL
 cpx
@@ -115960,11 +116644,11 @@ aae
 aae
 aae
 afn
-aaB
+elO
+mHP
 lTe
-lTe
-lTe
-aaB
+nkd
+elO
 aae
 aae
 aae
@@ -116036,7 +116720,7 @@ cpx
 cpx
 cpx
 cpx
-cpx
+pdm
 cpx
 cpx
 cpx
@@ -116120,19 +116804,19 @@ bgI
 aKP
 aKP
 nAt
-cvo
-xPu
-xPu
-xPu
+dpL
+pgy
+jMr
+jMr
 kBI
-xPu
-xPu
+jMr
+jMr
 xPu
 xPu
 xPu
 iVI
 uKE
-rmP
+cvo
 rmP
 rmP
 rmP
@@ -116140,7 +116824,7 @@ bfZ
 rmP
 rmP
 rmP
-rmP
+ify
 pMY
 dZL
 cpx
@@ -116218,10 +116902,10 @@ aae
 aae
 aae
 afn
-aaB
-lTe
-lTe
-aaB
+elO
+xpV
+nkd
+elO
 afn
 aae
 aae
@@ -116377,14 +117061,14 @@ bgI
 oNY
 bbd
 nAt
-cvo
+dpL
+pgy
 xPu
-xPu
-xPu
-xPu
-xPu
-xPu
-xPu
+jMr
+jbm
+jbm
+jMr
+jMr
 xPu
 xPu
 xPu
@@ -116397,7 +117081,7 @@ bge
 rmP
 rmP
 rmP
-rmP
+ify
 pMY
 dZL
 cpx
@@ -116439,7 +117123,7 @@ ovr
 wbm
 cAa
 opa
-agA
+pMW
 bmw
 jVJ
 jVJ
@@ -116475,11 +117159,11 @@ aae
 aae
 aae
 ahz
-aaB
+elO
+xpV
 lTe
-lTe
-lTe
-aaB
+bmb
+elO
 aae
 aae
 aae
@@ -116634,14 +117318,14 @@ bgI
 oNY
 bbd
 nAt
-cvo
-xPu
-xPu
-xPu
-xPu
-xPu
-xPu
-xPu
+dpL
+pgy
+jMr
+jMr
+jbm
+jbm
+jMr
+jMr
 xPu
 xPu
 sLz
@@ -116654,7 +117338,7 @@ bfZ
 aEr
 rmP
 eiK
-rmP
+ify
 pMY
 dZL
 cpx
@@ -116733,10 +117417,10 @@ aae
 aae
 aae
 afn
+mHP
 lTe
-lTe
-bfy
-aaB
+nfS
+elO
 afn
 aae
 aae
@@ -116817,7 +117501,7 @@ cpx
 cpx
 kbA
 cpx
-cpx
+pdm
 cpx
 cpx
 cpx
@@ -116891,19 +117575,19 @@ asX
 aKP
 aKP
 nAt
-cvo
-xPu
-xPu
-xPu
-xPu
-xPu
+dpL
+pgy
+jMr
+jMr
+jMr
+jMr
 xPu
 bfp
 xPu
 xPu
 jPD
 wnj
-rmP
+cvo
 rmP
 rmP
 rmP
@@ -116911,7 +117595,7 @@ bfZ
 rmP
 rmP
 rmP
-rmP
+ify
 pMY
 dZL
 cpx
@@ -116991,10 +117675,10 @@ aae
 aae
 afn
 qKg
-gNG
-gNG
+bOD
+wCJ
 qKg
-wOu
+cqQ
 aae
 ijB
 qOL
@@ -117038,7 +117722,7 @@ qOL
 qOL
 qOL
 qOL
-qOL
+ehQ
 cpx
 cpx
 cpx
@@ -117150,17 +117834,17 @@ lIb
 nAt
 dQT
 sLz
-sLz
-sLz
-sLz
-sLz
-sLz
-sLz
-sLz
+dnw
+dnw
+dnw
+dnw
+dnw
+dnw
+dnw
 sLz
 pMY
 nAt
-rmP
+cvo
 rmP
 rmP
 rmP
@@ -117168,7 +117852,7 @@ bga
 eiK
 rmP
 rmP
-rmP
+ify
 pMY
 dZL
 cpx
@@ -117248,8 +117932,8 @@ aae
 aae
 qKg
 qKg
-gNG
-gNG
+bOD
+wCJ
 qKg
 qKg
 qKg
@@ -117417,7 +118101,7 @@ qLf
 qLf
 dVg
 nAt
-rmP
+cvo
 rmP
 rmP
 rmP
@@ -117425,7 +118109,7 @@ bfZ
 rmP
 rmP
 rmP
-rmP
+ify
 pMY
 dZL
 cpx
@@ -117505,13 +118189,13 @@ aae
 aae
 fWm
 qKg
+bOD
 gNG
-gNG
-gNG
+kJM
 qKg
-wOu
+cqQ
 qpz
-iBT
+xIa
 iBT
 iBT
 iBT
@@ -117674,7 +118358,7 @@ vJu
 esK
 vJu
 nAt
-rmP
+cvo
 rmP
 rmP
 rmP
@@ -117682,7 +118366,7 @@ bfZ
 rmP
 rmP
 rmP
-rmP
+ify
 pMY
 dZL
 pdm
@@ -117762,9 +118446,9 @@ aaf
 aaf
 qKg
 qKg
+bOD
 gNG
-gNG
-gNG
+wCJ
 qKg
 qKg
 ijB
@@ -117818,7 +118502,7 @@ knn
 knn
 knn
 axt
-rmP
+fgL
 rmP
 rmP
 ayV
@@ -117826,9 +118510,6 @@ knn
 knn
 knn
 knn
-azs
-ylE
-wUg
 knn
 knn
 knn
@@ -117845,9 +118526,12 @@ knn
 knn
 knn
 knn
-azs
-ylE
-wUg
+knn
+knn
+knn
+knn
+knn
+knn
 knn
 knn
 knn
@@ -117860,16 +118544,16 @@ knn
 knn
 knn
 uKE
-mTD
-afs
-afs
+cvo
+rmP
+rmP
 iVI
 knn
 knn
 knn
 knn
-uKE
-rmP
+axt
+fgL
 tkv
 tkv
 ayV
@@ -117931,7 +118615,7 @@ knn
 knn
 knn
 wHm
-rmP
+cvo
 rmP
 rmP
 rmP
@@ -117939,7 +118623,7 @@ bfZ
 rmP
 rmP
 rmP
-rmP
+ify
 pMY
 dZL
 cpx
@@ -118007,187 +118691,187 @@ aaa
 (230,1,1) = {"
 aag
 wkv
-aao
-aao
-aao
-aas
-aao
-aao
-aao
-aao
-aao
+hKY
+dip
+dip
+dip
+dip
+dip
+dip
+hKY
+hKY
 acL
 qKg
-wOu
+cqQ
+bOD
 gNG
-gNG
-gNG
+wCJ
 fWm
 qKg
-qpz
-rHm
-rHm
-rHm
-rHm
-rHm
-rHm
-rHm
-rHm
-rHm
-rHm
-rHm
-rHm
-rHm
-rHm
-rHm
-rHm
-rHm
-rHm
-rHm
-rHm
-rHm
-rHm
-rHm
-rHm
-rHm
-rHm
-rHm
-rHm
-rHm
-rHm
-rHm
-rHm
-rHm
-rHm
-rHm
-rHm
-rHm
-rHm
-rHm
-rHm
-rHm
-rHm
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-eiK
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
+fBg
+lQs
+lQs
+lQs
+lQs
+lQs
+lQs
+jmf
+jmf
+jmf
+jmf
+lQs
+lQs
+lQs
+lQs
+lQs
+jmf
+jmf
+jmf
+jmf
+jmf
+jmf
+jmf
+jmf
+jmf
+jmf
+lQs
+lQs
+lQs
+lQs
+jmf
+jmf
+jmf
+jmf
+jmf
+jmf
+jmf
+lQs
+lQs
+lQs
+lQs
+lQs
+jmf
+auZ
+auZ
+auZ
+auZ
+kdL
+kdL
+kdL
+xPu
+xPu
+xPu
+xPu
+xPu
+kdL
+kdL
+kdL
+kdL
+kdL
+kdL
+kdL
+kdL
+auZ
+auZ
+auZ
+auZ
+auZ
+auZ
+auZ
+auZ
+kdL
+kdL
+kdL
+auZ
+auZ
+auZ
+auZ
+auZ
+auZ
+auZ
+auZ
+auZ
+auZ
+auZ
+kdL
 aKh
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
+kdL
+kdL
+kdL
+kdL
+kdL
+kdL
+xPu
+xPu
+xPu
+kdL
+kdL
+kdL
+kdL
+kdL
+xPu
+xPu
+xPu
+xPu
+xPu
+kdL
+kdL
+kdL
+kdL
+kdL
+kdL
+xPu
+xPu
+kdL
 aTT
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
+kdL
+kdL
+kdL
+kdL
+kdL
+kdL
+kdL
+kdL
+kdL
+kdL
+kdL
+auZ
+auZ
+auZ
+auZ
+auZ
+auZ
+auZ
+auZ
+auZ
+kdL
+auZ
+auZ
+auZ
+auZ
+kdL
+kdL
+kdL
+kdL
+kdL
+auZ
+auZ
+auZ
+auZ
+kdL
+kdL
+kdL
+kdL
+auZ
+auZ
+auZ
+auZ
+auZ
+kdL
+kdL
+kdL
+kdL
+kdL
 rmP
 rmP
 rmP
@@ -118196,7 +118880,7 @@ bfZ
 rmP
 rmP
 rmP
-rmP
+ify
 pMY
 dZL
 cpx
@@ -118263,16 +118947,16 @@ aaa
 "}
 (231,1,1) = {"
 oGu
-aao
-aao
-aao
-aao
-aao
-aao
-aao
-aao
-aao
-aao
+aas
+aas
+aas
+mdh
+ais
+mdh
+mdh
+aas
+aas
+aas
 aaf
 aax
 aaE
@@ -118286,7 +118970,13 @@ tbC
 rHm
 rHm
 rHm
-fnd
+rHm
+rHm
+rHm
+nfu
+moJ
+moJ
+nfu
 rHm
 rHm
 rHm
@@ -118294,14 +118984,10 @@ rHm
 rHm
 rHm
 rHm
-rHm
-rHm
-rHm
-rHm
-rHm
-rHm
-fnd
+nfu
 wLX
+nfu
+nfu
 rHm
 rHm
 rHm
@@ -118311,140 +118997,138 @@ rHm
 rHm
 rHm
 rHm
-rHm
-fnd
-rHm
-rHm
-rHm
-rHm
-rHm
+nfu
+moJ
+moJ
+nfu
+nfu
 rHm
 rHm
 rHm
 rHm
 rHm
 rHm
-eiK
-rmP
-rmP
-rmP
-rmP
-eiK
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-eiK
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-aes
-rmP
-rmP
-eiK
-eiK
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-eiK
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-eiK
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-acq
-acq
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-aes
-rmP
-aEr
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-eiK
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-ayz
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-eiK
-rmP
-rmP
-rmP
+xPu
+jMr
+jMr
+jMr
+xPu
+xPu
+xPu
+xPu
+xPu
+xPu
+xPu
+xPu
+jMr
+jMr
+jMr
+xPu
+xPu
+xPu
+xPu
+xPu
+xPu
+xPu
+xPu
+jMr
+jMr
+jMr
+xPu
+xPu
+xPu
+xPu
+xPu
+jMr
+jMr
+jMr
+jMr
+jMr
+jMr
+xPu
+xPu
+xPu
+xPu
+xPu
+xPu
+xPu
+jMr
+jMr
+xPu
+xPu
+xPu
+xPu
+xPu
+xPu
+xPu
+xPu
+xPu
+xPu
+xPu
+xPu
+xPu
+xPu
+xPu
+xPu
+xPu
+xPu
+xPu
+xPu
+xPu
+xPu
+xPu
+xPu
+xPu
+lRq
+lRq
+jMr
+jMr
+jMr
+jMr
+xPu
+jMr
+xPu
+xPu
+xPu
+xPu
+xPu
+aDD
+xPu
+xPu
+xPu
+jMr
+jMr
+xPu
+xPu
+xPu
+jMr
+jMr
+jbm
+jbm
+jMr
+jMr
+jMr
+xPu
+xPu
+xPu
+jMr
+jMr
+xPu
+xPu
+xPu
+lRq
+xPu
+xPu
+xPu
+jMr
+jMr
+jMr
+xPu
+xPu
+xPu
+xPu
+xPu
+xPu
 rmP
 rmP
 eiK
@@ -118453,7 +119137,7 @@ bga
 rmP
 rmP
 eiK
-rmP
+ify
 pMY
 dZL
 cpx
@@ -118520,44 +119204,17 @@ aaa
 "}
 (232,1,1) = {"
 wiN
-aao
-aao
-aao
-aao
-aao
-aao
-aao
-aao
 aas
-aao
-aao
-rHm
-rHm
-rHm
-fnd
-rHm
-rHm
-rHm
-rHm
-rHm
-rHm
-fnd
-rHm
-rHm
-rHm
-rHm
-rHm
-rHm
-rHm
-fnd
-rHm
-rHm
-rHm
-rHm
-rHm
-rHm
-rHm
-fnd
+aas
+mdh
+ais
+ais
+mdh
+aas
+aas
+aas
+aas
+aas
 rHm
 rHm
 rHm
@@ -118567,6 +119224,16 @@ rHm
 rHm
 rHm
 rHm
+nfu
+nfu
+nfu
+rHm
+rHm
+rHm
+nfu
+csY
+moJ
+nfu
 rHm
 rHm
 rHm
@@ -118574,134 +119241,151 @@ rHm
 rHm
 rHm
 rHm
-fnd
-fnd
-fnd
+nfu
+nfu
+moJ
+moJ
+nfu
+nfu
+nfu
 rHm
 rHm
 rHm
 rHm
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-aes
-aes
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-acq
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-eiK
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-aes
-aes
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-acq
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-eiK
-rmP
-rmP
-aes
-aes
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
+rHm
+rHm
+nfu
+nfu
+moJ
+nfu
+nfu
+rHm
+rHm
+rHm
+rHm
+rHm
+rHm
+jMr
+jbm
+jbm
+jMr
+jMr
+xPu
+xPu
+xPu
+xPu
+xPu
+xPu
+xPu
+jMr
+jbm
+jMr
+jMr
+xPu
+xPu
+xPu
+xPu
+xPu
+jMr
+jMr
+jMr
+jbm
+jMr
+xPu
+xPu
+xPu
+xPu
+xPu
+jMr
+jMr
+jMr
+jMr
+jMr
+jMr
+xPu
+xPu
+xPu
+xPu
+xPu
+xPu
+jMr
+jbm
+jMr
+jMr
+jMr
+xPu
+xPu
+xPu
+xPu
+xPu
+xPu
+otr
+jMr
+jMr
+jMr
+jMr
+xPu
+xPu
+xPu
+xPu
+xPu
+xPu
+xPu
+xPu
+xPu
+xPu
+xPu
+xPu
+xPu
+jbm
+jMr
+jMr
+jbm
+jMr
+jMr
+jMr
+xPu
+xPu
+xPu
+xPu
+xPu
+xPu
+jMr
+jMr
+jMr
+xPu
+xPu
+lRq
+xPu
+xPu
+jMr
+jMr
+jbm
+jMr
+jMr
+xPu
+xPu
+xPu
+xPu
+jMr
+jMr
+jbm
+jMr
+jMr
+xPu
+xPu
+xPu
+jMr
+jMr
+jbm
+jbm
+jMr
+jMr
+jMr
+jMr
+jMr
+xPu
+xPu
 rmP
 rmP
 rmP
@@ -118710,7 +119394,7 @@ bfZ
 rmP
 rmP
 rmP
-rmP
+ify
 pMY
 dZL
 cpx
@@ -118779,48 +119463,48 @@ aaa
 xwV
 aas
 aas
+mdh
+ais
+ais
+mdh
+mdh
 aas
-aao
-aao
-aao
-aao
-aao
-aao
 aas
-aao
+aas
+aas
+rHm
+rHm
+rHm
+rHm
+rHm
+nfu
+nfu
+nfu
+nfu
+moJ
+moJ
+nfu
+rHm
+rHm
+rHm
+nfu
+nfu
+nfu
+moJ
+nfu
 rHm
 rHm
 rHm
 rHm
 rHm
 rHm
-rHm
-rHm
-rHm
-rHm
-rHm
-rHm
-rHm
-rHm
-rHm
-rHm
-rHm
-rHm
-rHm
-rHm
-rHm
-rHm
-rHm
-rHm
-rHm
-rHm
-rHm
-rHm
-rHm
-rHm
-rHm
-rHm
-rHm
+nfu
+nfu
+moJ
+csY
+moJ
+nfu
+nfu
 rHm
 qsM
 rHm
@@ -118828,137 +119512,137 @@ rHm
 rHm
 rHm
 rHm
+nfu
+nfu
+moJ
+moJ
+nfu
+nfu
 rHm
 rHm
 rHm
 rHm
-rHm
-rHm
-rHm
-rHm
-rHm
-rHm
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-eiK
-rmP
-rmP
-rmP
-acq
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-acq
-aes
-aes
-rmP
-rmP
-aeY
-rmP
-pCk
-rmP
-grH
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-eiK
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-aes
-aes
-rmP
-rmP
-rmP
-rmP
-pCk
-eiK
-grH
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-aes
-aes
-rmP
-rmP
-rmP
-rmP
-pCk
-rmP
-grH
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
+xPu
+jMr
+jbm
+jbm
+jMr
+jMr
+xPu
+xPu
+xPu
+xPu
+xPu
+xPu
+jMr
+jMr
+oXJ
+jbm
+jMr
+xPu
+lRq
+xPu
+xPu
+jMr
+jMr
+jbm
+jbm
+jMr
+jMr
+xPu
+xPu
+xPu
+xPu
+xPu
+jMr
+jMr
+jMr
+otr
+jMr
+xPu
+xPu
+xPu
+aWS
+xPu
+jMr
+jMr
+jbm
+jbm
+jMr
+jMr
+jMr
+jMr
+xPu
+xPu
+xPu
+jMr
+jMr
+jMr
+jbm
+jbm
+jbm
+jMr
+xPu
+xPu
+xPu
+xPu
+jMr
+jMr
+xPu
+xPu
+jMr
+jMr
+jMr
+jMr
+jbm
+jbm
+jbm
+upZ
+jbm
+jMr
+jMr
+jMr
+jMr
+xPu
+xPu
+xPu
+jMr
+jMr
+upZ
+jbm
+jMr
+jMr
+xPu
+xPu
+jMr
+jMr
+jMr
+jbm
+jMr
+jMr
+jMr
+jMr
+xPu
+xPu
+jMr
+jbm
+jbm
+jbm
+jMr
+jMr
+xPu
+xPu
+xPu
+jMr
+jMr
+jbm
+jbm
+jMr
+jbm
+jbm
+jMr
+xPu
+xPu
 rmP
 rmP
 rmP
@@ -118967,7 +119651,7 @@ bfZ
 rmP
 rmP
 rmP
-rmP
+ify
 pMY
 dZL
 cpx
@@ -119037,14 +119721,14 @@ xwV
 acA
 aaz
 aaz
-acA
-acA
-aaz
-aaz
-aaz
-aaz
-aao
-aao
+tGL
+tGL
+aPZ
+aPZ
+qQl
+qQl
+mdh
+aas
 rHm
 iwV
 rXG
@@ -119052,19 +119736,19 @@ rXG
 rHm
 dJf
 hFW
-dJf
-rXG
-jdf
-rXG
-iwV
+hMa
+fEW
+cZr
+kCa
+mzW
 fLM
 sCs
 qsM
 jdf
 rXG
 rXG
-rXG
-iwV
+fEW
+mzW
 fLM
 sCs
 iwV
@@ -119072,148 +119756,148 @@ rXG
 rXG
 iwV
 iwV
-iwV
-rXG
-rXG
-rXG
+mzW
+fEW
+fEW
+kCa
+cZr
 jdf
 jdf
-jdf
 rXG
 rXG
-rXG
-rXG
-rXG
+fEW
+fEW
+fEW
 rXG
 iwV
-fLM
-sCs
-iwV
-rXG
+vEF
+mqr
+mzW
+fEW
+rWs
 qsM
-qsM
 iwV
 rXG
 rXG
-add
-add
-add
+aXv
+aXv
+wCN
+aIA
+ghv
 acH
 acH
-acH
-acH
-add
-aee
+aXv
+tGc
 vdf
 ayD
-add
-add
-add
-add
-add
-acH
+aXv
+wCN
+wCN
+ftH
+ftH
+aIA
 agj
 agH
+aIA
+wCN
+wCN
+ftH
+ftH
+ghv
+aIA
+aIA
 acH
-add
-add
-add
-add
-acH
-acH
-acH
-acH
-add
-add
-add
-add
-add
-agj
+wCN
+wCN
+aXv
+aXv
+aXv
+xcq
 agH
+aIA
+wCN
+aXv
 acH
-add
-add
-acH
-rmP
-rmP
-rmP
-afs
-add
-add
-afs
-add
-add
-acH
-agj
-agH
-add
-add
-add
-add
-add
-acH
-acH
-acH
-aee
-aPM
-ayD
-add
-acH
-agj
-agH
-acH
-add
-add
-add
-add
-acH
-acH
-add
-add
-add
-acH
-agj
-agH
-acH
-add
-add
-acH
-aee
-ayD
-ayD
-afs
-add
-add
+xPu
+xPu
+xPu
 afs
 aXv
-add
+wCN
+cqC
+ftH
+wCN
+aIA
+xcq
+agH
+aXv
+aXv
+wCN
+wCN
+wCN
+ghv
+tEP
+aIA
+tGc
+tGc
+ayD
+aXv
 acH
+xcq
+agA
+aIA
+aXv
+wCN
+wCN
+wCN
+aIA
+acH
+wCN
+wCN
+ftH
+aIA
+xcq
+agA
+aIA
+wCN
+aXv
+acH
+aPM
+ayD
+iyd
+cqC
+ftH
+wCN
+afs
+aXv
+aXv
+aIA
 agj
 agH
+aIA
+wCN
+wCN
+aXv
+aXv
+wCN
+wCN
+wCN
+lZY
+kPX
+aIA
+wCN
+wCN
 acH
-add
-add
-add
-add
-add
-add
-add
-agj
-agH
-acH
-add
-add
-acH
-rmP
-rmP
-rmP
+xPu
+xPu
+xPu
+cqC
+ucS
+wCN
 afs
-adc
-add
-afs
-acq
-add
-acH
+otr
+wCN
+aIA
 agj
 agH
 aet
@@ -119224,7 +119908,7 @@ bge
 rmP
 rmP
 rmP
-rmP
+ify
 pMY
 dZL
 cpx
@@ -119291,17 +119975,17 @@ aaa
 "}
 (235,1,1) = {"
 gvL
-aao
-aao
-aao
+aas
+aas
+aas
 aaS
-aao
-aao
-aao
-aao
-aao
-aao
-aao
+aas
+ais
+ais
+mdh
+mdh
+mdh
+aas
 rHm
 rHm
 rHm
@@ -119311,11 +119995,8 @@ rHm
 rHm
 rHm
 rHm
-rHm
-rHm
-fnd
-rHm
-rHm
+nfu
+nfu
 rHm
 rHm
 rHm
@@ -119324,155 +120005,158 @@ rHm
 rHm
 rHm
 rHm
-fnd
+nfu
+nfu
+nfu
+nfu
+nfu
+rHm
+rHm
+rHm
+rHm
+nfu
+nfu
+nfu
+rHm
+rHm
+rHm
+rHm
+rHm
+nfu
+moJ
+nfu
+rHm
+rHm
+rHm
+nfu
+nfu
 rHm
 rHm
 rHm
 rHm
 rHm
 rHm
-rHm
-rHm
-rHm
-rHm
-rHm
-rHm
-rHm
-rHm
-rHm
-rHm
-rHm
-rHm
-rHm
-rHm
-rHm
-rHm
-rHm
-rHm
-rHm
-rHm
-rHm
-rmP
-rmP
-eiK
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-eiK
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-aes
-eiK
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-aes
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-eiK
-rmP
-rmP
-aes
-eiK
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-aes
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-aes
-eiK
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-aes
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-eiK
+xPu
+xPu
+xPu
+xPu
+jMr
+jMr
+xPu
+jMr
+jMr
+jMr
+xPu
+xPu
+xPu
+xPu
+jMr
+jbm
+jMr
+xPu
+xPu
+xPu
+xPu
+jMr
+jMr
+jMr
+jMr
+xPu
+xPu
+jMr
+jMr
+jMr
+xPu
+xPu
+xPu
+xPu
+xPu
+xPu
+jMr
+xPu
+xPu
+xPu
+xPu
+xPu
+xPu
+xPu
+xPu
+jMr
+jMr
+jMr
+jMr
+xPu
+xPu
+xPu
+xPu
+xPu
+jMr
+jMr
+jMr
+jMr
+jMr
+jMr
+jMr
+xPu
+xPu
+xPu
+jMr
+jMr
+jMr
+jMr
+jMr
+xPu
+xPu
+xPu
+xPu
+jMr
+jbm
+jbm
+jMr
+jMr
+jMr
+xPu
+xPu
+jMr
+jMr
+jMr
+xPu
+xPu
+xPu
+jMr
+jMr
+xPu
+jMr
+jMr
+jMr
+xPu
+xPu
+jMr
+jMr
+jMr
+xPu
+xPu
+jMr
+jMr
+jMr
+jMr
+jMr
+jMr
+xPu
+xPu
+jMr
+jMr
+jMr
+xPu
+xPu
+jMr
+jMr
+xPu
+xPu
+xPu
+xPu
+xPu
+xPu
 rmP
 rmP
 rmP
@@ -119481,7 +120165,7 @@ bfZ
 rmP
 eiK
 rmP
-rmP
+ify
 pMY
 dZL
 cpx
@@ -119551,29 +120235,14 @@ lew
 aas
 aas
 aas
-aao
-aao
-aao
-aao
-aao
-aao
+mdh
+mdh
+mdh
+mdh
+mdh
 aas
-aao
-rHm
-rHm
-rHm
-rHm
-fnd
-rHm
-rHm
-rHm
-rHm
-rHm
-rHm
-rHm
-rHm
-rHm
-fnd
+aas
+aas
 rHm
 rHm
 rHm
@@ -119583,6 +120252,21 @@ rHm
 rHm
 rHm
 rHm
+rHm
+rHm
+rHm
+rHm
+rHm
+rHm
+rHm
+rHm
+rHm
+rHm
+moJ
+moJ
+moJ
+nfu
+nfu
 rHm
 qsM
 rHm
@@ -119593,143 +120277,143 @@ rHm
 rHm
 rHm
 rHm
+nfu
+moJ
+csY
+nfu
+nfu
 rHm
 rHm
 rHm
 rHm
+nfu
+nfu
+nfu
+nfu
 rHm
 rHm
 rHm
-rHm
-rHm
-rHm
-rHm
-rHm
-rHm
-rHm
-fnd
-rHm
-rmP
-rmP
-rmP
-rmP
-rmP
-awy
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-aeY
-rmP
-eiK
-rmP
-acq
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-adc
-rmP
-rmP
-rmP
-rmP
-rmP
-acq
+xPu
+xPu
+xPu
+xPu
+xPu
 lRq
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-eiK
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-acq
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-awy
-acq
-acq
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-pCk
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-eiK
-aeY
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-pCk
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
+xPu
+xPu
+jMr
+jMr
+jMr
+jMr
+xPu
+xPu
+xPu
+jMr
+jMr
+xPu
+xPu
+xPu
+xPu
+xPu
+aWS
+xPu
+jMr
+xPu
+otr
+jMr
+jMr
+jMr
+jMr
+xPu
+xPu
+xPu
+xPu
+xPu
+xPu
+dYp
+xPu
+xPu
+xPu
+jMr
+jMr
+otr
+otr
+jMr
+jMr
+xPu
+xPu
+xPu
+xPu
+xPu
+xPu
+xPu
+xPu
+jMr
+jMr
+jbm
+jMr
+jMr
+jMr
+xPu
+xPu
+lRq
+xPu
+jbm
+jbm
+jMr
+jMr
+xPu
+xPu
+xPu
+xPu
+xPu
+xPu
+xPu
+xPu
+xPu
+xPu
+lRq
+lRq
+otr
+jMr
+jMr
+xPu
+xPu
+xPu
+xPu
+xPu
+xPu
+jMr
+jMr
+xPu
+xPu
+xPu
+xPu
+xPu
+aWS
+xPu
+xPu
+xPu
+xPu
+xPu
+xPu
+xPu
+jMr
+xPu
+xPu
+xPu
+xPu
+xPu
+xPu
+xPu
+xPu
+xPu
+jMr
+xPu
+xPu
+xPu
+xPu
+xPu
 rmP
 rmP
 rmP
@@ -119738,7 +120422,7 @@ bfZ
 rmP
 rmP
 rmP
-rmP
+ify
 pMY
 dZL
 cpx
@@ -119805,16 +120489,16 @@ aaa
 "}
 (237,1,1) = {"
 irY
-aao
-aao
-aao
-aao
-aao
-aao
-aao
-aao
-aao
-aao
+aas
+aas
+aas
+aas
+mdh
+mdh
+mdh
+aas
+aas
+aas
 aaf
 aay
 aaE
@@ -119833,18 +120517,12 @@ jmh
 rHm
 rHm
 rHm
-rHm
-rHm
-rHm
-rHm
-rHm
-ptn
-fnd
-rHm
-rHm
-rHm
-rHm
-rHm
+nfu
+nfu
+moJ
+csY
+nfu
+xTs
 rHm
 rHm
 rHm
@@ -119856,137 +120534,143 @@ rHm
 rHm
 rHm
 rHm
-rHm
-rHm
-rHm
-rHm
-fnd
+nfu
+nfu
 rHm
 rHm
 rHm
 rHm
 rHm
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-aes
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
+rHm
+nfu
+nfu
+nfu
+nfu
+nfu
+nfu
+rHm
+rHm
+xPu
+xPu
+xPu
+xPu
+xPu
+xPu
+xPu
+xPu
+xPu
+jMr
+jMr
+jMr
+xPu
+xPu
+xPu
+xPu
+xPu
+xPu
+xPu
+xPu
+xPu
+xPu
+xPu
+xPu
+xPu
+xPu
+jMr
+jMr
+jMr
+jMr
+jMr
+xPu
+xPu
+xPu
+xPu
+xPu
+xPu
+xPu
+xPu
+xPu
+xPu
+xPu
+xPu
+xPu
+xPu
+xPu
+xPu
+xPu
+xPu
 bTk
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-aeY
-rmP
-rmP
-aes
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-aes
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
+xPu
+xPu
+xPu
+xPu
+xPu
+xPu
+jMr
+jMr
+jMr
+jMr
+xPu
+xPu
+xPu
+xPu
+xPu
+jMr
+jMr
+jMr
+xPu
+xPu
+xPu
+xPu
+xPu
+xPu
+xPu
+xPu
+xPu
+xPu
+xPu
+xPu
+xPu
+aWS
+jMr
+jMr
+xPu
+xPu
+xPu
+xPu
+xPu
+xPu
+xPu
+xPu
+xPu
+xPu
+xPu
+xPu
+xPu
+xPu
+xPu
+xPu
+xPu
+xPu
+xPu
+xPu
+xPu
+xPu
+xPu
+xPu
+xPu
+xPu
+xPu
+xPu
+xPu
+xPu
+xPu
+xPu
+xPu
+xPu
+xPu
+xPu
+xPu
 rmP
 rmP
 rmP
@@ -119995,7 +120679,7 @@ bgg
 rmP
 rmP
 rmP
-rmP
+ify
 pMY
 dZL
 qRe
@@ -120064,10 +120748,10 @@ aaa
 aag
 mfk
 aao
-aao
-aao
-aao
-aao
+nzi
+nzi
+nzi
+nzi
 aao
 aao
 aao
@@ -120075,175 +120759,175 @@ aao
 acL
 fWm
 qKg
+bOD
 gNG
-gNG
-gNG
-wOu
+nWK
+cqQ
 qKg
-qpz
-rHm
-rHm
-rHm
-rHm
-rHm
-rHm
-rHm
-rHm
-rHm
-rHm
-rHm
-rHm
-rHm
-rHm
-rHm
-rHm
-rHm
-rHm
-ptn
-rHm
-rHm
-rHm
+fBg
 fnd
-rHm
-rHm
-rHm
-rHm
-rHm
-rHm
-rHm
-rHm
-rHm
-rHm
-rHm
-rHm
-rHm
-rHm
-rHm
-rHm
-rHm
-rHm
-rHm
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-eiK
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
+fnd
+lgq
+lgq
+lgq
+fnd
+fnd
+lgq
+lgq
+lgq
+lgq
+lgq
+lgq
+lgq
+fnd
+fnd
+fnd
+fnd
+ptn
+fnd
+fnd
+fnd
+fnd
+lgq
+lgq
+lgq
+lgq
+lgq
+lgq
+fnd
+fnd
+fnd
+fnd
+fnd
+lgq
+lgq
+lgq
+lgq
+lgq
+fnd
+fnd
+fnd
+sLz
+sLz
+sLz
+sLz
+sLz
+dnw
+dnw
+dnw
+dnw
+dnw
+dnw
+sLz
+sLz
+dnw
+dnw
+dnw
+dnw
+dnw
+dnw
+sLz
+sLz
+sLz
+sLz
+sLz
+sLz
+dnw
+dnw
+dnw
+dnw
+dnw
+dnw
+dnw
+sLz
+sLz
+sLz
+dnw
+dnw
+dnw
+dnw
+dnw
+dnw
+sLz
+sLz
+sLz
+sLz
+sLz
 amf
-rmP
+dnw
 lUl
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-acq
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
-eiK
-rmP
-rmP
-rmP
-rmP
-rmP
-rmP
+dnw
+dnw
+sLz
+sLz
+dnw
+dnw
+dnw
+dnw
+dnw
+dnw
+dnw
+dnw
+dnw
+sLz
+sLz
+dnw
+dnw
+dnw
+dnw
+dnw
+dnw
+dnw
+dnw
+dnw
+sLz
+sLz
+sLz
+sLz
+sLz
+sLz
+sLz
+sLz
+sLz
+sLz
+dnw
+dnw
+dnw
+dnw
+dnw
+dnw
+dnw
+dnw
+dnw
+dnw
+dnw
+dnw
+sLz
+sLz
+sLz
+mfX
+dnw
+dnw
+dnw
+dnw
+dnw
+dnw
+dnw
+dnw
+dnw
+dnw
+dnw
+dnw
+dnw
+dnw
+dnw
+sLz
+sLz
+sLz
+sLz
+sLz
+sLz
+sLz
 rmP
 rmP
 rmP
@@ -120252,7 +120936,7 @@ bfZ
 rmP
 rmP
 rmP
-rmP
+ify
 pMY
 dZL
 oiq
@@ -120331,7 +121015,7 @@ aaf
 aaf
 aaf
 qKg
-gNG
+xad
 gNG
 brn
 qKg
@@ -120501,7 +121185,7 @@ qLf
 qLf
 qLf
 wnj
-rmP
+cvo
 rmP
 adc
 rmP
@@ -120509,7 +121193,7 @@ bfZ
 rmP
 rmP
 rmP
-rmP
+ify
 pMY
 dZL
 aaM
@@ -120588,14 +121272,14 @@ aae
 aae
 qKg
 qKg
+bOD
 gNG
-gNG
-gNG
+nWK
 qKg
 qKg
-wOu
+cqQ
 qpz
-lBv
+hHo
 lBv
 lBv
 lBv
@@ -120758,7 +121442,7 @@ fgp
 fgp
 uBw
 nAt
-rmP
+cvo
 rmP
 rmP
 rmP
@@ -120766,7 +121450,7 @@ bgg
 rmP
 rmP
 rmP
-rmP
+ify
 pMY
 dZL
 cpx
@@ -120844,9 +121528,9 @@ aae
 aae
 aae
 aae
+xad
 gNG
-gNG
-gNG
+nWK
 qKg
 qKg
 cbo
@@ -121015,7 +121699,7 @@ cpx
 cpx
 pkJ
 nAt
-rmP
+cvo
 rmP
 rmP
 rmP
@@ -121023,7 +121707,7 @@ bfZ
 eiK
 rmP
 rmP
-rmP
+ify
 pMY
 dZL
 cpx
@@ -121102,12 +121786,12 @@ aae
 aae
 lTe
 lTe
-gNG
-qKg
+wCJ
+upd
 wOu
-qKg
-fWm
-qKg
+wOu
+wOu
+wOu
 ijB
 qWV
 qWV
@@ -121203,6 +121887,7 @@ cpx
 cpx
 cpx
 cpx
+qRe
 cpx
 cpx
 cpx
@@ -121220,6 +121905,7 @@ cpx
 cpx
 cpx
 cpx
+kbA
 cpx
 cpx
 cpx
@@ -121227,9 +121913,7 @@ cpx
 cpx
 cpx
 cpx
-cpx
-cpx
-cpx
+qRe
 cpx
 cpx
 cpx
@@ -121272,7 +121956,7 @@ cpx
 cpx
 pkJ
 nAt
-rmP
+cvo
 rmP
 rmP
 rmP
@@ -121280,7 +121964,7 @@ bfZ
 rmP
 rmP
 rmP
-rmP
+ify
 pMY
 dZL
 pdm
@@ -121361,10 +122045,10 @@ lTe
 lTe
 aae
 adg
-mdh
-mdh
-mdh
-mdh
+qWV
+qWV
+qWV
+qWV
 nGe
 qOL
 qOL
@@ -121402,12 +122086,12 @@ qOL
 qOL
 qOL
 qOL
+ehQ
 qOL
 qOL
+ehQ
 qOL
 qOL
-qOL
-qOL
 cpx
 cpx
 cpx
@@ -121437,7 +122121,7 @@ cpx
 cpx
 cpx
 cpx
-cpx
+kbA
 cpx
 cpx
 cpx
@@ -121451,6 +122135,7 @@ cpx
 cpx
 cpx
 cpx
+kbA
 cpx
 cpx
 cpx
@@ -121467,8 +122152,7 @@ cpx
 cpx
 cpx
 cpx
-cpx
-cpx
+qRe
 cpx
 cpx
 cuu
@@ -121495,7 +122179,7 @@ cpx
 cpx
 cpx
 cpx
-cpx
+kbA
 cpx
 cpx
 cpx
@@ -121529,7 +122213,7 @@ cpx
 qRe
 pkJ
 nAt
-rmP
+cvo
 rmP
 rmP
 rmP
@@ -121537,7 +122221,7 @@ bfZ
 rmP
 rmP
 rmP
-rmP
+ify
 pMY
 dZL
 qRe
@@ -121724,6 +122408,26 @@ cpx
 cpx
 cpx
 cpx
+kbA
+cpx
+cpx
+cpx
+cpx
+cpx
+cpx
+cpx
+cpx
+cpx
+qRe
+cpx
+cpx
+cpx
+cpx
+cpx
+cpx
+cpx
+cpx
+kbA
 cpx
 cpx
 cpx
@@ -121735,27 +122439,7 @@ cpx
 cpx
 cpx
 cpx
-cpx
-cpx
-cpx
-cpx
-cpx
-cpx
-cpx
-cpx
-cpx
-cpx
-cpx
-cpx
-cpx
-cpx
-cpx
-cpx
-cpx
-cpx
-cpx
-cpx
-cpx
+qRe
 cpx
 cpx
 cpx
@@ -121786,7 +122470,7 @@ cpx
 lIm
 pkJ
 nAt
-rmP
+cvo
 eiK
 rmP
 rmP
@@ -121794,7 +122478,7 @@ bgg
 rmP
 rmP
 rmP
-rmP
+ify
 pMY
 dZL
 aYA
@@ -121966,7 +122650,7 @@ cpx
 cpx
 cpx
 cpx
-cpx
+qRe
 cpx
 cpx
 cpx
@@ -122043,7 +122727,7 @@ cpx
 cpx
 pkJ
 nAt
-rmP
+cvo
 rmP
 rmP
 rmP
@@ -122051,7 +122735,7 @@ bfZ
 rmP
 rmP
 rmP
-eiK
+ify
 pMY
 dZL
 cpx
@@ -122300,7 +122984,7 @@ cpx
 cpx
 pkJ
 nAt
-rmP
+cvo
 rmP
 rmP
 rmP
@@ -122308,7 +122992,7 @@ bfZ
 rmP
 rmP
 rmP
-rmP
+ify
 pMY
 dZL
 cpx
@@ -122557,7 +123241,7 @@ cpx
 cpx
 pkJ
 nAt
-rmP
+cvo
 rmP
 aeY
 rmP
@@ -122565,7 +123249,7 @@ bfZ
 rmP
 rmP
 rmP
-rmP
+ify
 pMY
 dZL
 aae
@@ -122814,7 +123498,7 @@ cpx
 cpx
 pkJ
 nAt
-rmP
+cvo
 rmP
 rmP
 rmP
@@ -122822,7 +123506,7 @@ bfZ
 rmP
 rmP
 rmP
-rmP
+ify
 pMY
 dZL
 aae
@@ -123071,7 +123755,7 @@ aae
 cpx
 koD
 nAt
-rmP
+cvo
 eiK
 rmP
 rmP
@@ -123079,7 +123763,7 @@ bfZ
 acq
 rmP
 rmP
-rmP
+ify
 pMY
 vjo
 aae
@@ -123328,7 +124012,7 @@ aae
 aab
 mMT
 arx
-aud
+bhI
 aud
 aud
 aud
@@ -123336,7 +124020,7 @@ awf
 aud
 aud
 aud
-aud
+aLh
 aym
 aab
 adg
@@ -123585,7 +124269,7 @@ aae
 aae
 mMT
 arx
-aud
+bhI
 aud
 aud
 aud
@@ -123593,7 +124277,7 @@ awf
 aud
 aud
 aud
-aud
+aLh
 aym
 aab
 aae
@@ -123842,7 +124526,7 @@ aae
 aae
 mMT
 arx
-aud
+bhI
 aud
 aud
 aud
@@ -123850,7 +124534,7 @@ awf
 aud
 aud
 aud
-aud
+aLh
 aym
 aab
 aae
@@ -124099,7 +124783,7 @@ aae
 aae
 mMT
 ast
-sSC
+ptm
 sSC
 sSC
 auy
@@ -124107,7 +124791,7 @@ wNm
 sSC
 sSC
 sSC
-sSC
+cSh
 ayF
 aab
 aae
@@ -124356,7 +125040,7 @@ aae
 aae
 mMT
 asA
-aus
+iNZ
 aus
 aus
 aus
@@ -124364,7 +125048,7 @@ awV
 aus
 aus
 aus
-aus
+dCu
 ayG
 aab
 aae

--- a/_maps/map_files/Pahrump-Sunset/Pahrump-Sunset.dmm
+++ b/_maps/map_files/Pahrump-Sunset/Pahrump-Sunset.dmm
@@ -1679,13 +1679,10 @@
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland/west)
 "agA" = (
-/obj/effect/decal/marking{
-	icon_state = "doubleverticaltop"
+/turf/open/indestructible/ground/outside/desert{
+	icon_state = "wasteland32"
 	},
-/turf/open/indestructible/ground/outside/road{
-	icon_state = "verticalinnermain1"
-	},
-/area/f13/wasteland/east)
+/area/f13/wasteland/museum)
 "agB" = (
 /obj/machinery/shower{
 	dir = 8
@@ -2170,10 +2167,13 @@
 /turf/open/indestructible/ground/outside/sidewalk,
 /area/f13/wasteland/train)
 "ais" = (
+/obj/effect/decal/marking{
+	icon_state = "doubleverticalcorroded"
+	},
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "verticalinnermain2"
 	},
-/area/f13/tunnel/northeast)
+/area/f13/wasteland/east)
 "aiw" = (
 /mob/living/simple_animal/hostile/ghoul/reaver,
 /turf/open/indestructible/ground/outside/dirt{
@@ -9424,13 +9424,10 @@
 	},
 /area/f13/building/firestation)
 "aIA" = (
-/obj/effect/decal/marking{
-	icon_state = "doubleverticalcorroded"
-	},
 /turf/open/indestructible/ground/outside/road{
-	icon_state = "verticalinnermain1"
+	icon_state = "verticalinnermain2"
 	},
-/area/f13/wasteland/east)
+/area/f13/wasteland/train)
 "aIB" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -9503,7 +9500,7 @@
 "aIQ" = (
 /obj/structure/barricade/wooden,
 /turf/open/indestructible/ground/outside/road{
-	icon_state = "verticalrightborderleft0"
+	icon_state = "verticalrightborderleft1"
 	},
 /area/f13/wasteland/east)
 "aIR" = (
@@ -11659,14 +11656,6 @@
 	icon_state = "horizontalinnermain0"
 	},
 /area/f13/wasteland/firestation)
-"aPZ" = (
-/obj/effect/decal/marking{
-	icon_state = "doublevertical"
-	},
-/turf/open/indestructible/ground/outside/road{
-	icon_state = "verticalinnermain2"
-	},
-/area/f13/tunnel/northeast)
 "aQa" = (
 /obj/structure/barricade/wooden,
 /turf/open/indestructible/ground/outside/road{
@@ -12996,11 +12985,10 @@
 	},
 /area/f13/wasteland/east)
 "aUI" = (
-/obj/structure/barricade/sandbags,
 /turf/open/indestructible/ground/outside/road{
-	icon_state = "verticalleftborderright2"
+	icon_state = "verticalrightborderleft1"
 	},
-/area/f13/wasteland/west)
+/area/f13/wasteland/train)
 "aUJ" = (
 /obj/structure/sink{
 	pixel_y = 15
@@ -18021,12 +18009,6 @@
 	},
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland/west)
-"bmb" = (
-/obj/effect/turf_decal/weather/dirt{
-	dir = 10
-	},
-/turf/open/indestructible/ground/outside/water,
-/area/f13/caves)
 "bmc" = (
 /turf/closed/indestructible/rock,
 /area/f13/tunnel/sub)
@@ -18515,6 +18497,13 @@
 /obj/machinery/smartfridge/bottlerack/lootshelf/brews,
 /turf/open/floor/f13/wood,
 /area/f13/building)
+"bnS" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/observer_start,
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "horizontalinnermain1"
+	},
+/area/f13/wasteland/bighorn)
 "bnU" = (
 /obj/machinery/computer/terminal{
 	density = 0;
@@ -20947,12 +20936,6 @@
 	icon_state = "horizontalinnermain1"
 	},
 /area/f13/wasteland/west)
-"bOD" = (
-/obj/effect/turf_decal/weather/dirt{
-	dir = 1
-	},
-/turf/open/indestructible/ground/outside/water,
-/area/f13/wasteland/train)
 "bOE" = (
 /obj/effect/decal/cleanable/chem_pile,
 /turf/open/floor/plasteel/f13{
@@ -22869,13 +22852,10 @@
 /turf/open/indestructible/ground/outside/water,
 /area/f13/caves)
 "cqC" = (
-/obj/effect/decal/marking{
-	icon_state = "doubleverticaldegraded"
-	},
 /turf/open/indestructible/ground/outside/road{
-	icon_state = "verticalinnermain1"
+	icon_state = "horizontalbottombordertop0"
 	},
-/area/f13/wasteland/east)
+/area/f13/wasteland/museum)
 "cqD" = (
 /obj/structure/table/wood,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/hobo,
@@ -22911,10 +22891,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13/wood,
 /area/f13/building/museum)
-"cqQ" = (
-/obj/structure/flora/grass/wasteland,
-/turf/open/floor/plating/dirt,
-/area/f13/wasteland/train)
 "cqR" = (
 /obj/structure/table/wood,
 /obj/effect/spawner/lootdrop/f13/cash_random_low,
@@ -23140,10 +23116,13 @@
 /turf/open/floor/f13/wood,
 /area/f13/building/museum)
 "csY" = (
-/turf/open/indestructible/ground/outside/road{
-	icon_state = "horizontalinnermain3"
+/obj/effect/decal/marking{
+	icon_state = "doublevertical"
 	},
-/area/f13/wasteland/train)
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "verticalinnermain2"
+	},
+/area/f13/wasteland/east)
 "csZ" = (
 /obj/effect/decal/cleanable/blood/old,
 /turf/open/floor/f13/wood,
@@ -23814,6 +23793,12 @@
 	icon_state = "bluedirtychess"
 	},
 /area/f13/building/mall)
+"cJN" = (
+/obj/structure/chair/sofa/left{
+	dir = 1
+	},
+/turf/open/floor/carpet/red,
+/area/f13/bar/heaven)
 "cJY" = (
 /obj/structure/closet{
 	anchored = 1
@@ -24300,14 +24285,6 @@
 	},
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland/museum)
-"cZr" = (
-/obj/effect/decal/marking{
-	icon_state = "doubleverticaldegraded"
-	},
-/turf/open/indestructible/ground/outside/road{
-	icon_state = "verticalinnermain1"
-	},
-/area/f13/wasteland/train)
 "daa" = (
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "verticalleftborderright0"
@@ -24539,10 +24516,9 @@
 /turf/closed/wall/f13/tentwall,
 /area/f13/building)
 "dip" = (
-/turf/open/indestructible/ground/outside/road{
-	icon_state = "verticalleftborderright1"
-	},
-/area/f13/tunnel/northeast)
+/obj/structure/flora/grass/wasteland,
+/turf/open/floor/plating/dirt,
+/area/f13/wasteland/train)
 "diz" = (
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland/bighorn)
@@ -24745,8 +24721,11 @@
 	},
 /area/f13/wasteland/east)
 "dpL" = (
-/turf/open/floor/plating/f13/outside/road{
-	icon_state = "horizontaltopborderbottom1"
+/obj/effect/decal/marking{
+	icon_state = "doubleverticalcorroded"
+	},
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "verticalinnermain1"
 	},
 /area/f13/wasteland/east)
 "dpQ" = (
@@ -24937,6 +24916,14 @@
 "dvS" = (
 /turf/open/transparent/openspace,
 /area/f13/brotherhood)
+"dwc" = (
+/obj/effect/decal/marking{
+	icon_state = "doubleverticalbottom"
+	},
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "verticalinnermain1"
+	},
+/area/f13/wasteland/train)
 "dwe" = (
 /obj/structure/table/snooker{
 	dir = 6
@@ -25022,6 +25009,11 @@
 /obj/item/bedsheet/black,
 /turf/open/floor/wood/wood_common,
 /area/f13/followers)
+"dxB" = (
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "horizontaltopborderbottomleft"
+	},
+/area/f13/wasteland/east)
 "dxY" = (
 /obj/item/reagent_containers/pill/patch/turbo,
 /obj/item/storage/trash_stack,
@@ -25157,12 +25149,6 @@
 	icon_state = "darkrustysolid"
 	},
 /area/f13/radiation)
-"dCh" = (
-/obj/structure/chair/sofa/left{
-	dir = 1
-	},
-/turf/open/floor/carpet/red,
-/area/f13/bar/heaven)
 "dCu" = (
 /obj/effect/landmark/start/f13/wastelander,
 /turf/open/indestructible/ground/outside/road{
@@ -25319,6 +25305,20 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13/wood,
 /area/f13/building/museum)
+"dGd" = (
+/obj/structure/sign/poster/prewar/poster74{
+	pixel_y = 32
+	},
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
+/obj/structure/rack,
+/obj/effect/spawner/lootdrop/f13/medical/wasteland/meds,
+/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite/rarecyan,
+/area/f13/building)
 "dGh" = (
 /obj/item/stack/f13Cash/random/low,
 /turf/open/floor/f13/wood,
@@ -25581,6 +25581,11 @@
 	icon_state = "innermaincornerouter"
 	},
 /area/f13/wasteland/massfusion)
+"dNW" = (
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "verticalleftborderright1"
+	},
+/area/f13/tunnel/northeast)
 "dOC" = (
 /obj/machinery/hydroponics/soil,
 /turf/open/indestructible/ground/outside/dirt,
@@ -26110,11 +26115,6 @@
 /obj/item/storage/trash_stack,
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland/quarry)
-"ehQ" = (
-/turf/open/indestructible/ground/outside/desert{
-	icon_state = "wasteland33"
-	},
-/area/f13/wasteland/train)
 "ehU" = (
 /obj/effect/spawner/lootdrop/f13/weapon/melee/random_mid,
 /turf/open/indestructible/ground/outside/dirt,
@@ -26178,6 +26178,11 @@
 	icon_state = "outerpavement"
 	},
 /area/f13/wasteland/bighorn)
+"ekq" = (
+/obj/structure/sink/deep_water,
+/obj/effect/turf_decal/weather/dirt,
+/turf/open/indestructible/ground/outside/water,
+/area/f13/caves)
 "ekW" = (
 /obj/machinery/vending/medical,
 /obj/effect/decal/cleanable/dirt,
@@ -26222,8 +26227,11 @@
 	},
 /area/f13/wasteland/massfusion)
 "elO" = (
-/turf/open/floor/plating/dirt,
-/area/f13/caves)
+/obj/effect/decal/remains/human,
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "verticalinnermain2"
+	},
+/area/f13/wasteland/east)
 "elP" = (
 /obj/structure/table/optable,
 /turf/open/floor/f13{
@@ -26889,11 +26897,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/white,
 /area/f13/village)
-"eHm" = (
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "verticaloutermain0"
-	},
-/area/f13/wasteland/east)
 "eHx" = (
 /obj/structure/railing{
 	dir = 10
@@ -27137,6 +27140,12 @@
 	icon_state = "bar"
 	},
 /area/f13/building)
+"eOb" = (
+/obj/effect/turf_decal/weather/dirt{
+	dir = 10
+	},
+/turf/open/indestructible/ground/outside/water,
+/area/f13/wasteland/train)
 "ePa" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
@@ -27482,6 +27491,14 @@
 	icon_state = "darkrustysolid"
 	},
 /area/f13/radiation)
+"eYN" = (
+/obj/effect/decal/marking{
+	icon_state = "doubleverticalbottom"
+	},
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "verticalinnermain1"
+	},
+/area/f13/wasteland/east)
 "eZp" = (
 /obj/structure/rack,
 /obj/item/storage/pill_bottle/chem_tin/radx,
@@ -28097,6 +28114,12 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/building/firestation)
+"frP" = (
+/obj/structure/car,
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "horizontalbottombordertop0"
+	},
+/area/f13/wasteland/museum)
 "frQ" = (
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "horizontaltopbordertop0"
@@ -28135,14 +28158,6 @@
 /obj/structure/flora/grass/wasteland,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/caves)
-"ftH" = (
-/obj/effect/decal/marking{
-	icon_state = "doublevertical"
-	},
-/turf/open/indestructible/ground/outside/road{
-	icon_state = "verticalinnermain2"
-	},
-/area/f13/wasteland/east)
 "ftI" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -28455,13 +28470,6 @@
 /obj/machinery/mineral/wasteland_vendor/mining,
 /turf/open/floor/wood/wood_mosaic,
 /area/f13/city/bighorn)
-"fBg" = (
-/obj/structure/fence{
-	dir = 4
-	},
-/obj/structure/barricade/wooden/planks/pregame,
-/turf/open/floor/plating/dirt,
-/area/f13/wasteland/train)
 "fBF" = (
 /obj/effect/turf_decal/weather/dirt{
 	dir = 1
@@ -28548,7 +28556,7 @@
 /area/f13/wasteland/west)
 "fEW" = (
 /obj/effect/decal/marking{
-	icon_state = "doublevertical"
+	icon_state = "doubleverticaldegraded"
 	},
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "verticalinnermain1"
@@ -28751,13 +28759,11 @@
 	},
 /turf/open/indestructible/ground/outside/sidewalk,
 /area/f13/wasteland/bighorn)
-"fKS" = (
-/obj/item/circuitboard/machine/chem_dispenser/drinks,
-/turf/closed/wall/f13/store{
-	desc = "A pre-War wall made of solid concrete.";
-	name = "concrete wall"
+"fKM" = (
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "verticalinnermain1"
 	},
-/area/f13/building)
+/area/f13/tunnel/northeast)
 "fKY" = (
 /obj/structure/dresser,
 /turf/open/floor/carpet/black,
@@ -29211,6 +29217,15 @@
 	icon_state = "horizontaltopborderbottom0"
 	},
 /area/f13/wasteland/heaven)
+"fXN" = (
+/obj/structure/bed/mattress{
+	icon_state = "mattress2";
+	pixel_y = 7
+	},
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "verticalinnermain0"
+	},
+/area/f13/wasteland/east)
 "fXY" = (
 /obj/effect/turf_decal/box/white,
 /obj/effect/decal/cleanable/dirt{
@@ -29451,14 +29466,6 @@
 /obj/structure/flora/grass/wasteland,
 /turf/open/indestructible/ground/outside/savannah/leftcenter,
 /area/f13/caves)
-"ghv" = (
-/obj/effect/decal/marking{
-	icon_state = "doubleverticalcorroded"
-	},
-/turf/open/indestructible/ground/outside/road{
-	icon_state = "verticalinnermain2"
-	},
-/area/f13/wasteland/east)
 "ghC" = (
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "verticalinnermain1"
@@ -30416,6 +30423,12 @@
 	},
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/village)
+"gNv" = (
+/obj/effect/overlay/desert/sonora/edge/corner{
+	dir = 4
+	},
+/turf/open/floor/plating/dirt,
+/area/f13/wasteland/train)
 "gNw" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13{
@@ -30505,15 +30518,6 @@
 	destination_z = 9
 	},
 /area/f13/tunnel/southeast)
-"gPD" = (
-/obj/structure/frame/machine,
-/obj/item/stack/cable_coil/random/five,
-/obj/item/circuitboard/machine/chem_dispenser,
-/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite{
-	icon_state = "showroomfloor";
-	name = "tile"
-	},
-/area/f13/building)
 "gQf" = (
 /obj/machinery/computer/shuttle/bos{
 	dir = 8;
@@ -30563,6 +30567,11 @@
 	icon_state = "rubble"
 	},
 /area/f13/wasteland/west)
+"gRN" = (
+/turf/open/indestructible/ground/outside/desert{
+	icon_state = "wasteland32"
+	},
+/area/f13/ruins)
 "gRY" = (
 /obj/effect/turf_decal/weather/dirt{
 	dir = 4
@@ -30887,6 +30896,10 @@
 	icon_state = "horizontaloutermain2"
 	},
 /area/f13/wasteland/bighorn)
+"haL" = (
+/obj/machinery/light/sign/chiken_ranch,
+/turf/open/indestructible/ground/outside/sidewalk,
+/area/f13/wasteland/heaven)
 "haR" = (
 /obj/structure/chair/wood{
 	dir = 8
@@ -31050,6 +31063,12 @@
 	icon_state = "savannah6"
 	},
 /area/f13/wasteland/valley)
+"hfi" = (
+/obj/structure/cargocrate,
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "horizontalinnermain0"
+	},
+/area/f13/wasteland/east)
 "hfr" = (
 /obj/structure/flora/grass/wasteland{
 	icon_state = "tall_grass_6"
@@ -31140,6 +31159,13 @@
 /obj/item/kirbyplants/random,
 /turf/open/floor/plasteel/f13/vault_floor/misc/bar,
 /area/f13/city/bighorn)
+"hkf" = (
+/obj/item/circuitboard/machine/chem_dispenser/drinks,
+/turf/closed/wall/f13/store{
+	desc = "A pre-War wall made of solid concrete.";
+	name = "concrete wall"
+	},
+/area/f13/building)
 "hkk" = (
 /obj/structure/rack/shelf_metal,
 /obj/effect/spawner/lootdrop/f13/crafting,
@@ -31188,6 +31214,11 @@
 	name = "concrete wall"
 	},
 /area/f13/building/museum)
+"hlr" = (
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "verticaloutermain0"
+	},
+/area/f13/wasteland/east)
 "hlD" = (
 /obj/structure/car/rubbish1,
 /turf/open/indestructible/ground/outside/road{
@@ -31841,14 +31872,6 @@
 	icon_state = "rubblecorner"
 	},
 /area/f13/wasteland/museum)
-"hMa" = (
-/obj/effect/decal/marking{
-	icon_state = "dottedverticalcorroded"
-	},
-/turf/open/indestructible/ground/outside/road{
-	icon_state = "verticalinnermain1"
-	},
-/area/f13/wasteland/train)
 "hMj" = (
 /obj/item/trash/popcorn,
 /turf/open/floor/f13/wood,
@@ -31947,7 +31970,7 @@
 /area/f13/caves)
 "hPs" = (
 /turf/open/indestructible/ground/outside/road{
-	icon_state = "horizontalbottombordertop0"
+	icon_state = "horizontalbottombordertop1"
 	},
 /area/f13/wasteland/firestation)
 "hPC" = (
@@ -32168,11 +32191,10 @@
 	},
 /area/f13/wasteland/west)
 "hVG" = (
-/obj/structure/barricade/sandbags,
 /turf/open/indestructible/ground/outside/road{
-	icon_state = "verticalrightborderleft0"
+	icon_state = "verticalinnermain2"
 	},
-/area/f13/wasteland/hospital)
+/area/f13/tunnel/northeast)
 "hVI" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -32194,14 +32216,6 @@
 	icon_state = "reddirtyfull"
 	},
 /area/f13/building/museum)
-"hWj" = (
-/obj/effect/decal/cleanable/glass,
-/obj/machinery/chem_heater,
-/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite{
-	icon_state = "showroomfloor";
-	name = "tile"
-	},
-/area/f13/building)
 "hWp" = (
 /turf/open/indestructible/ground/outside/sidewalk{
 	dir = 1;
@@ -32511,6 +32525,17 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/carpet,
 /area/f13/building/mall)
+"ifU" = (
+/obj/structure/rack,
+/obj/item/cane,
+/obj/item/cane,
+/obj/item/cane,
+/obj/item/cane,
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/neutral/neutralsolid,
+/area/f13/building)
 "iga" = (
 /turf/open/floor/f13{
 	icon_state = "white"
@@ -32879,6 +32904,14 @@
 	icon_state = "horizontalbottomborderbottom2right"
 	},
 /area/f13/wasteland/west)
+"itD" = (
+/obj/effect/decal/cleanable/glass,
+/obj/machinery/chem_heater,
+/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite{
+	icon_state = "showroomfloor";
+	name = "tile"
+	},
+/area/f13/building)
 "itH" = (
 /obj/machinery/light,
 /obj/effect/decal/cleanable/dirt,
@@ -33089,14 +33122,6 @@
 	icon_state = "dirt"
 	},
 /area/f13/building)
-"iyd" = (
-/obj/effect/decal/marking{
-	icon_state = "dottedverticaldegraded"
-	},
-/turf/open/indestructible/ground/outside/road{
-	icon_state = "verticalinnermain1"
-	},
-/area/f13/wasteland/east)
 "izc" = (
 /turf/open/indestructible/ground/outside/desert{
 	icon_state = "wasteland33"
@@ -33209,6 +33234,14 @@
 "iBU" = (
 /turf/closed/mineral/random/low_chance,
 /area/f13/building/massfusion)
+"iBX" = (
+/obj/effect/decal/marking{
+	icon_state = "doubleverticaltop"
+	},
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "verticalinnermain1"
+	},
+/area/f13/wasteland/east)
 "iCa" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/indestructible/ground/outside/ruins,
@@ -33579,7 +33612,7 @@
 "iMm" = (
 /obj/structure/barricade/sandbags,
 /turf/open/indestructible/ground/outside/road{
-	icon_state = "verticalinnermain0"
+	icon_state = "verticalinnermain1"
 	},
 /area/f13/wasteland/firestation)
 "iMu" = (
@@ -33786,6 +33819,11 @@
 /obj/effect/decal/remains/human,
 /turf/open/floor/f13/wood,
 /area/f13/building/museum)
+"iQT" = (
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "horizontalinnermain3"
+	},
+/area/f13/wasteland/train)
 "iRl" = (
 /obj/structure/window/fulltile/house{
 	icon_state = "storewindowbottom"
@@ -33858,12 +33896,6 @@
 	icon_state = "verticalleftborderleft3"
 	},
 /area/f13/wasteland/hospital)
-"iTb" = (
-/turf/open/indestructible/ground/outside/ruins{
-	dir = 1;
-	icon_state = "rubblecorner"
-	},
-/area/f13/wasteland/nanotrasen)
 "iTd" = (
 /obj/structure/flora/grass/wasteland{
 	icon_state = "tall_grass_3"
@@ -33950,6 +33982,14 @@
 	icon_state = "bluedirtychess2"
 	},
 /area/f13/village)
+"iUW" = (
+/obj/effect/decal/marking{
+	icon_state = "doubleverticalbottom"
+	},
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "verticalinnermain2"
+	},
+/area/f13/wasteland/east)
 "iVo" = (
 /obj/structure/flora/grass/wasteland{
 	icon_state = "tall_grass_6"
@@ -34404,6 +34444,14 @@
 	icon_state = "yellowrustysolid"
 	},
 /area/f13/building/massfusion)
+"jgP" = (
+/obj/effect/decal/marking{
+	icon_state = "dottedverticalcorroded"
+	},
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "verticalinnermain1"
+	},
+/area/f13/wasteland/train)
 "jgS" = (
 /obj/machinery/hydroponics/soil{
 	name = "riverbed soil";
@@ -34503,12 +34551,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/freezer,
 /area/f13/brotherhood)
-"jiT" = (
-/obj/machinery/vending/coffee,
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "horizontaloutermain2"
-	},
-/area/f13/wasteland/heaven)
 "jiX" = (
 /obj/effect/decal/riverbank,
 /obj/structure/fence/wooden{
@@ -34677,7 +34719,7 @@
 /area/f13/building)
 "jmf" = (
 /turf/open/indestructible/ground/outside/road{
-	icon_state = "verticalleftborderright1"
+	icon_state = "verticalinnermain1"
 	},
 /area/f13/wasteland/train)
 "jmh" = (
@@ -35750,6 +35792,15 @@
 	icon_state = "darkrusty"
 	},
 /area/f13/building/massfusion)
+"kba" = (
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
+/obj/structure/chair/f13chair1{
+	dir = 1
+	},
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "kbA" = (
 /obj/structure/flora/tree/tall,
 /turf/open/indestructible/ground/outside/desert,
@@ -35976,6 +36027,12 @@
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/superlow,
 /turf/open/floor/f13/wood,
 /area/f13/village)
+"kkj" = (
+/obj/effect/turf_decal/weather/dirt{
+	dir = 9
+	},
+/turf/open/indestructible/ground/outside/water,
+/area/f13/wasteland/train)
 "kku" = (
 /obj/effect/turf_decal/stripes/asteroid/line,
 /turf/open/indestructible/ground/outside/road{
@@ -36510,14 +36567,6 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/red/white/side,
 /area/f13/building/mall)
-"kCa" = (
-/obj/effect/decal/marking{
-	icon_state = "doublevertical"
-	},
-/turf/open/indestructible/ground/outside/road{
-	icon_state = "verticalinnermain2"
-	},
-/area/f13/wasteland/train)
 "kCd" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_y = 28
@@ -36797,6 +36846,14 @@
 "kIS" = (
 /turf/open/floor/carpet,
 /area/f13/city/bighorn)
+"kJa" = (
+/obj/effect/decal/marking{
+	icon_state = "doublevertical"
+	},
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "verticalinnermain1"
+	},
+/area/f13/tunnel/northeast)
 "kJj" = (
 /obj/structure/wreck/trash/two_barrels,
 /obj/effect/turf_decal/stripes/asteroid/line{
@@ -36816,12 +36873,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vault1,
 /area/f13/building/museum)
-"kJM" = (
-/obj/effect/turf_decal/weather/dirt{
-	dir = 10
-	},
-/turf/open/indestructible/ground/outside/water,
-/area/f13/wasteland/train)
 "kJO" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -36991,14 +37042,6 @@
 	icon_state = "horizontaltopborderbottom2right"
 	},
 /area/f13/wasteland/bighorn)
-"kPX" = (
-/obj/effect/decal/marking{
-	icon_state = "doubleverticaltop"
-	},
-/turf/open/indestructible/ground/outside/road{
-	icon_state = "verticalinnermain2"
-	},
-/area/f13/wasteland/east)
 "kQj" = (
 /obj/structure/railing{
 	dir = 1
@@ -37278,14 +37321,10 @@
 /turf/open/floor/plasteel/f13/vault_floor/white,
 /area/f13/building/hospital)
 "kXR" = (
-/obj/structure/table_frame,
-/obj/effect/decal/cleanable/glass,
-/obj/item/shard,
-/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite{
-	icon_state = "showroomfloor";
-	name = "tile"
+/turf/open/indestructible/ground/outside/desert{
+	icon_state = "wasteland32"
 	},
-/area/f13/building)
+/area/f13/wasteland/bighornbunker)
 "kXT" = (
 /obj/item/flashlight/lantern,
 /turf/open/indestructible/ground/inside/mountain,
@@ -37541,11 +37580,6 @@
 	icon_state = "verticalinnermain2top"
 	},
 /area/f13/wasteland/west)
-"lgq" = (
-/turf/open/indestructible/ground/outside/road{
-	icon_state = "verticalrightborderleft1"
-	},
-/area/f13/wasteland/train)
 "lgD" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/small{
@@ -37695,6 +37729,12 @@
 	},
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/building)
+"ljD" = (
+/obj/structure/car/rubbish1,
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "verticalinnermain1"
+	},
+/area/f13/wasteland/east)
 "ljK" = (
 /obj/item/stack/f13Cash/random/low,
 /turf/open/floor/f13{
@@ -38057,6 +38097,11 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/building)
+"lvB" = (
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "verticalrightborderleft1"
+	},
+/area/f13/tunnel/northeast)
 "lwj" = (
 /obj/structure/barricade/sandbags,
 /turf/open/indestructible/ground/inside/mountain,
@@ -38082,15 +38127,6 @@
 	icon_state = "white"
 	},
 /area/f13/brotherhood)
-"lwR" = (
-/obj/effect/decal/cleanable/dirt{
-	color = "000000"
-	},
-/obj/structure/chair/f13chair1{
-	dir = 1
-	},
-/turf/open/floor/f13/wood,
-/area/f13/building)
 "lwS" = (
 /obj/structure/flora/tree/tall{
 	icon_state = "tree_3"
@@ -38162,6 +38198,13 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/white,
 /area/f13/building/hospital)
+"lzK" = (
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
+/obj/machinery/autolathe/ammo/unlocked_basic,
+/turf/open/floor/f13/wood,
+/area/f13/building)
 "lzL" = (
 /obj/structure/window/fulltile/store{
 	icon_state = "ruinswindow"
@@ -38266,6 +38309,12 @@
 	icon_state = "verticaloutermaintop"
 	},
 /area/f13/wasteland/bighorn)
+"lCB" = (
+/obj/effect/turf_decal/weather/dirt{
+	dir = 1
+	},
+/turf/open/indestructible/ground/outside/water,
+/area/f13/wasteland/train)
 "lCN" = (
 /obj/structure/cable{
 	icon_state = "2-4"
@@ -38288,6 +38337,14 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/white,
 /area/f13/building/mall)
+"lDh" = (
+/obj/effect/decal/marking{
+	icon_state = "doubleverticalcorroded"
+	},
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "verticalinnermain1"
+	},
+/area/f13/tunnel/northeast)
 "lDv" = (
 /obj/structure/flora/grass/wasteland{
 	icon_state = "tall_grass_2";
@@ -38340,13 +38397,6 @@
 	},
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland/valley)
-"lEf" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/landmark/observer_start,
-/turf/open/indestructible/ground/outside/road{
-	icon_state = "horizontalinnermain1"
-	},
-/area/f13/wasteland/bighorn)
 "lEr" = (
 /obj/structure/car/rubbish1,
 /turf/open/indestructible/ground/outside/road{
@@ -38626,6 +38676,14 @@
 	icon_state = "horizontaloutermain1"
 	},
 /area/f13/bunker)
+"lMd" = (
+/obj/effect/decal/marking{
+	icon_state = "doublevertical"
+	},
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "verticalinnermain2"
+	},
+/area/f13/wasteland/train)
 "lMm" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
@@ -38757,6 +38815,11 @@
 /obj/structure/closet/crate/trashcart,
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "verticaloutermain2top"
+	},
+/area/f13/wasteland/east)
+"lOP" = (
+/turf/open/floor/plating/f13/outside/road{
+	icon_state = "horizontaltopborderbottom1"
 	},
 /area/f13/wasteland/east)
 "lPa" = (
@@ -38916,7 +38979,7 @@
 "lSQ" = (
 /obj/structure/barricade/sandbags,
 /turf/open/indestructible/ground/outside/road{
-	icon_state = "verticalrightborderleft0"
+	icon_state = "verticalrightborderleft1"
 	},
 /area/f13/wasteland/firestation)
 "lSY" = (
@@ -39157,14 +39220,6 @@
 /obj/item/instrument/guitar,
 /turf/open/floor/wood/wood_mosaic,
 /area/f13/building/mall)
-"lZY" = (
-/obj/effect/decal/marking{
-	icon_state = "doubleverticalbottom"
-	},
-/turf/open/indestructible/ground/outside/road{
-	icon_state = "verticalinnermain2"
-	},
-/area/f13/wasteland/east)
 "mai" = (
 /obj/effect/turf_decal/box/white,
 /obj/effect/decal/cleanable/dirt{
@@ -39189,10 +39244,13 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "mbs" = (
-/turf/open/indestructible/ground/outside/road{
-	icon_state = "horizontalbottombordertop0"
+/obj/effect/decal/marking{
+	icon_state = "doubleverticaldegraded"
 	},
-/area/f13/wasteland/museum)
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "verticalinnermain1"
+	},
+/area/f13/wasteland/east)
 "mbv" = (
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "horizontalbottombordertop0"
@@ -39302,10 +39360,9 @@
 	},
 /area/f13/wasteland/bighorn)
 "mdh" = (
-/turf/open/indestructible/ground/outside/road{
-	icon_state = "verticalinnermain1"
-	},
-/area/f13/tunnel/northeast)
+/obj/effect/turf_decal/weather/dirt,
+/turf/open/indestructible/ground/outside/water,
+/area/f13/wasteland/train)
 "mdP" = (
 /obj/item/clothing/accessory/medal/plasma/nobel_science{
 	name = "Medal of Science"
@@ -39313,17 +39370,6 @@
 /obj/structure/displaycase,
 /turf/open/floor/f13/wood,
 /area/f13/building/museum)
-"mea" = (
-/obj/structure/rack,
-/obj/item/cane,
-/obj/item/cane,
-/obj/item/cane,
-/obj/item/cane,
-/obj/effect/decal/cleanable/dirt{
-	color = "000000"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/neutral/neutralsolid,
-/area/f13/building)
 "meb" = (
 /obj/item/storage/trash_stack,
 /turf/open/indestructible/ground/outside/sidewalk,
@@ -39521,6 +39567,13 @@
 	icon_state = "outerpavement"
 	},
 /area/f13/wasteland/bighorn)
+"mjA" = (
+/obj/structure/barricade/wooden,
+/obj/structure/barricade/wooden/planks/pregame,
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "verticalleftborderright1"
+	},
+/area/f13/wasteland/east)
 "mkh" = (
 /obj/structure/table/booth,
 /obj/effect/spawner/lootdrop/f13/junkspawners,
@@ -39552,6 +39605,12 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/neutral/neutralchess/neutralchess2,
 /area/f13/building/firestation)
+"mkR" = (
+/obj/machinery/vending/coffee,
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "horizontaloutermain2"
+	},
+/area/f13/wasteland/heaven)
 "mkU" = (
 /obj/structure/closet/fridge,
 /obj/effect/spawner/lootdrop/f13/foodspawner,
@@ -39701,7 +39760,7 @@
 /area/f13/wasteland/hospital)
 "moJ" = (
 /turf/open/indestructible/ground/outside/road{
-	icon_state = "verticalinnermain2"
+	icon_state = "verticalleftborderright1"
 	},
 /area/f13/wasteland/train)
 "moV" = (
@@ -39767,14 +39826,6 @@
 	icon_state = "floorrustysolid"
 	},
 /area/f13/building/mall)
-"mqr" = (
-/obj/effect/decal/marking{
-	icon_state = "doubleverticaltop"
-	},
-/turf/open/indestructible/ground/outside/road{
-	icon_state = "verticalinnermain1"
-	},
-/area/f13/wasteland/train)
 "mqx" = (
 /obj/effect/decal/waste,
 /turf/open/indestructible/ground/outside/road{
@@ -40059,12 +40110,12 @@
 /area/f13/city/bighorn)
 "mzW" = (
 /obj/effect/decal/marking{
-	icon_state = "doubleverticalcorroded"
+	icon_state = "dottedverticalcorroded"
 	},
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "verticalinnermain1"
 	},
-/area/f13/wasteland/train)
+/area/f13/wasteland/east)
 "mAf" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -40336,12 +40387,6 @@
 /obj/machinery/workbench,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
-"mHP" = (
-/obj/effect/turf_decal/weather/dirt{
-	dir = 5
-	},
-/turf/open/indestructible/ground/outside/water,
-/area/f13/caves)
 "mHZ" = (
 /turf/open/floor/f13/wood,
 /area/f13/city/bighorn)
@@ -40514,13 +40559,6 @@
 	icon_state = "verticalleftborderleft2"
 	},
 /area/f13/building/hospital)
-"mOP" = (
-/obj/effect/decal/cleanable/dirt{
-	color = "000000"
-	},
-/obj/machinery/autolathe/ammo/unlocked_basic,
-/turf/open/floor/f13/wood,
-/area/f13/building)
 "mOV" = (
 /obj/effect/decal/cleanable/generic,
 /obj/effect/decal/cleanable/dirt,
@@ -40882,7 +40920,7 @@
 	pixel_y = 32
 	},
 /turf/open/indestructible/ground/outside/road{
-	icon_state = "verticalinnermain0"
+	icon_state = "horizontalinnermain0"
 	},
 /area/f13/wasteland/east)
 "mZR" = (
@@ -41050,15 +41088,15 @@
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland/valley)
 "nfu" = (
-/turf/open/indestructible/ground/outside/road{
-	icon_state = "verticalinnermain1"
+/obj/structure/fence{
+	dir = 4
 	},
+/obj/structure/barricade/wooden/planks/pregame,
+/obj/effect/overlay/desert/sonora/edge{
+	dir = 1
+	},
+/turf/open/floor/plating/dirt,
 /area/f13/wasteland/train)
-"nfS" = (
-/obj/structure/sink/deep_water,
-/obj/effect/turf_decal/weather/dirt,
-/turf/open/indestructible/ground/outside/water,
-/area/f13/caves)
 "ngi" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13{
@@ -41690,10 +41728,13 @@
 /turf/open/floor/f13/wood,
 /area/f13/building)
 "nzi" = (
-/turf/open/indestructible/ground/outside/road{
-	icon_state = "verticalrightborderleft1"
+/obj/effect/decal/marking{
+	icon_state = "doublevertical"
 	},
-/area/f13/tunnel/northeast)
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "verticalinnermain1"
+	},
+/area/f13/wasteland/east)
 "nzp" = (
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "horizontalbottomborderbottom0"
@@ -42388,12 +42429,6 @@
 	icon_state = "rampdowntop"
 	},
 /area/f13/city/bighorn)
-"nWK" = (
-/obj/effect/turf_decal/weather/dirt{
-	dir = 6
-	},
-/turf/open/indestructible/ground/outside/water,
-/area/f13/wasteland/train)
 "nWT" = (
 /turf/open/indestructible/ground/outside/road{
 	dir = 8;
@@ -42665,11 +42700,6 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/village)
-"ofD" = (
-/turf/open/indestructible/ground/outside/road{
-	icon_state = "verticalleftborderright1"
-	},
-/area/f13/wasteland/heaven)
 "ofG" = (
 /obj/effect/turf_decal/weather/dirt{
 	dir = 8
@@ -42740,6 +42770,12 @@
 /obj/item/clothing/under/f13/petrochico,
 /turf/open/floor/plasteel/f13/vault_floor/dark,
 /area/f13/building/mall)
+"ohZ" = (
+/obj/effect/turf_decal/weather/dirt{
+	dir = 5
+	},
+/turf/open/indestructible/ground/outside/water,
+/area/f13/caves)
 "oid" = (
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "verticaloutermain2bottom"
@@ -43155,12 +43191,6 @@
 	icon_state = "innershade"
 	},
 /area/f13/wasteland/west)
-"otr" = (
-/obj/effect/spawner/lootdrop/f13/junkspawners,
-/turf/open/indestructible/ground/outside/road{
-	icon_state = "verticalinnermain1"
-	},
-/area/f13/wasteland/east)
 "otA" = (
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "verticalrightborderright1"
@@ -43904,6 +43934,15 @@
 	},
 /turf/open/indestructible/ground/outside/savannah/topcenter,
 /area/f13/caves)
+"oPv" = (
+/obj/structure/frame/machine,
+/obj/item/stack/cable_coil/random/five,
+/obj/item/circuitboard/machine/chem_dispenser,
+/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite{
+	icon_state = "showroomfloor";
+	name = "tile"
+	},
+/area/f13/building)
 "oPA" = (
 /obj/structure/table/wood,
 /obj/item/reagent_containers/food/drinks/beer,
@@ -43933,15 +43972,6 @@
 	},
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland/bighorn)
-"oPW" = (
-/obj/structure/bed/mattress{
-	icon_state = "mattress2";
-	pixel_y = 7
-	},
-/turf/open/indestructible/ground/outside/road{
-	icon_state = "verticalinnermain0"
-	},
-/area/f13/wasteland/east)
 "oPX" = (
 /obj/structure/chair/wood{
 	dir = 4
@@ -44053,11 +44083,6 @@
 "oUj" = (
 /turf/open/floor/f13/wood,
 /area/f13/village)
-"oUk" = (
-/turf/open/indestructible/ground/outside/road{
-	icon_state = "horizontaltopborderbottomleft"
-	},
-/area/f13/wasteland/east)
 "oUo" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/hobo,
@@ -44734,6 +44759,11 @@
 	icon_state = "verticalinnermain3"
 	},
 /area/f13/wasteland/firestation)
+"prm" = (
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "outerpavementcorner"
+	},
+/area/f13/wasteland/train)
 "pro" = (
 /obj/effect/spawner/lootdrop/f13/medical/rnd/mid,
 /obj/effect/spawner/lootdrop/f13/junkspawners,
@@ -45759,20 +45789,6 @@
 	},
 /turf/open/floor/wood/wood_common,
 /area/f13/followers)
-"pYf" = (
-/obj/structure/sign/poster/prewar/poster74{
-	pixel_y = 32
-	},
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt{
-	color = "000000"
-	},
-/obj/structure/rack,
-/obj/effect/spawner/lootdrop/f13/medical/wasteland/meds,
-/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite/rarecyan,
-/area/f13/building)
 "pYi" = (
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "horizontalinnermain2"
@@ -45982,10 +45998,11 @@
 	},
 /area/f13/wasteland/museum)
 "qgl" = (
-/turf/open/indestructible/ground/outside/desert{
-	icon_state = "wasteland32"
+/obj/effect/spawner/lootdrop/f13/junkspawners,
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "verticalinnermain1"
 	},
-/area/f13/wasteland/museum)
+/area/f13/wasteland/train)
 "qgB" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -46097,6 +46114,12 @@
 	},
 /turf/open/floor/carpet/red,
 /area/f13/bar/heaven)
+"qjv" = (
+/obj/effect/turf_decal/weather/dirt{
+	dir = 6
+	},
+/turf/open/indestructible/ground/outside/water,
+/area/f13/wasteland/train)
 "qke" = (
 /obj/effect/turf_decal/weather/dirt{
 	dir = 10
@@ -46262,6 +46285,14 @@
 	},
 /turf/open/floor/wood/wood_mosaic,
 /area/f13/building/mall)
+"qnS" = (
+/obj/effect/decal/marking{
+	icon_state = "doubleverticaltop"
+	},
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "verticalinnermain1"
+	},
+/area/f13/wasteland/train)
 "qof" = (
 /turf/open/indestructible/ground/outside/graveldirt,
 /area/f13/wasteland/bighorn)
@@ -46337,9 +46368,6 @@
 	dir = 4
 	},
 /obj/structure/barricade/wooden/planks/pregame,
-/obj/effect/overlay/desert/sonora/edge{
-	dir = 1
-	},
 /turf/open/floor/plating/dirt,
 /area/f13/wasteland/train)
 "qpA" = (
@@ -47175,14 +47203,6 @@
 	icon_state = "horizontaltopbordertop0"
 	},
 /area/f13/wasteland/nanotrasen)
-"qQl" = (
-/obj/effect/decal/marking{
-	icon_state = "doublevertical"
-	},
-/turf/open/indestructible/ground/outside/road{
-	icon_state = "verticalinnermain1"
-	},
-/area/f13/tunnel/northeast)
 "qQq" = (
 /obj/machinery/light{
 	dir = 4
@@ -47320,6 +47340,14 @@
 /obj/item/stamp/denied,
 /turf/open/floor/wood/wood_mosaic,
 /area/f13/followers)
+"qVO" = (
+/obj/effect/decal/marking{
+	icon_state = "doubleverticalcorroded"
+	},
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "horizontalinnermain3"
+	},
+/area/f13/wasteland/east)
 "qVY" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/machinery/smartfridge/bottlerack/lootshelf/diy,
@@ -47734,6 +47762,12 @@
 	icon_state = "innermaincornerinner"
 	},
 /area/f13/wasteland/east)
+"rhY" = (
+/obj/effect/turf_decal/weather/dirt{
+	dir = 10
+	},
+/turf/open/indestructible/ground/outside/water,
+/area/f13/caves)
 "rim" = (
 /obj/effect/turf_decal/stripes/asteroid/line{
 	dir = 1
@@ -47842,6 +47876,14 @@
 	icon_state = "darkrusty"
 	},
 /area/f13/building/mall)
+"rlH" = (
+/obj/effect/decal/marking{
+	icon_state = "doublevertical"
+	},
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "verticalinnermain2"
+	},
+/area/f13/tunnel/northeast)
 "rlJ" = (
 /obj/effect/landmark/start/f13/outsider,
 /turf/open/indestructible/ground/outside/road{
@@ -48313,6 +48355,12 @@
 /obj/effect/decal/cleanable/blood/old,
 /turf/closed/wall/f13/tentwall,
 /area/f13/building)
+"rxV" = (
+/obj/effect/spawner/lootdrop/f13/junkspawners,
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "verticalinnermain1"
+	},
+/area/f13/wasteland/east)
 "ryh" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/table/wood/poker,
@@ -48711,6 +48759,9 @@
 "rMu" = (
 /turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/building/mall)
+"rMv" = (
+/turf/open/floor/plating/dirt,
+/area/f13/caves)
 "rMz" = (
 /obj/item/storage/trash_stack,
 /turf/open/floor/plasteel/f13/vault_floor/plating,
@@ -49125,12 +49176,6 @@
 /obj/structure/legion_extractor,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/building)
-"rWs" = (
-/obj/effect/spawner/lootdrop/f13/junkspawners,
-/turf/open/indestructible/ground/outside/road{
-	icon_state = "verticalinnermain1"
-	},
-/area/f13/wasteland/train)
 "rWA" = (
 /obj/structure/flora/tree/tall,
 /turf/open/indestructible/ground/outside/desert,
@@ -50760,10 +50805,6 @@
 	icon_state = "verticalrightborderright0"
 	},
 /area/f13/wasteland/hospital)
-"sYy" = (
-/obj/machinery/light/sign/chiken_ranch,
-/turf/open/indestructible/ground/outside/sidewalk,
-/area/f13/wasteland/heaven)
 "sYC" = (
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "innermaincornerouter"
@@ -51021,6 +51062,14 @@
 /obj/structure/decoration/rag,
 /turf/open/indestructible/ground/outside/sidewalk,
 /area/f13/wasteland/bighorn)
+"tfM" = (
+/obj/effect/decal/marking{
+	icon_state = "doublevertical"
+	},
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "verticalinnermain1"
+	},
+/area/f13/wasteland/train)
 "tgs" = (
 /obj/effect/decal/cleanable/blood/old{
 	icon_state = "gib3-old";
@@ -51930,25 +51979,9 @@
 /obj/machinery/light,
 /turf/open/floor/plasteel/f13/vault_floor/blue/side,
 /area/f13/building/hospital)
-"tEP" = (
-/obj/effect/decal/marking{
-	icon_state = "doubleverticalcorroded"
-	},
-/turf/open/indestructible/ground/outside/road{
-	icon_state = "horizontalinnermain3"
-	},
-/area/f13/wasteland/east)
 "tFm" = (
 /turf/open/floor/plasteel/f13/vault_floor/white,
 /area/f13/building/hospital)
-"tGc" = (
-/obj/effect/decal/marking{
-	icon_state = "dottedverticalcorroded"
-	},
-/turf/open/indestructible/ground/outside/road{
-	icon_state = "verticalinnermain1"
-	},
-/area/f13/wasteland/east)
 "tGe" = (
 /obj/structure/closet/crate/bin/trashbin,
 /turf/open/floor/wood/wood_wide,
@@ -51991,14 +52024,6 @@
 	},
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland/valley)
-"tGL" = (
-/obj/effect/decal/marking{
-	icon_state = "doubleverticalcorroded"
-	},
-/turf/open/indestructible/ground/outside/road{
-	icon_state = "verticalinnermain1"
-	},
-/area/f13/tunnel/northeast)
 "tGQ" = (
 /obj/structure/flora/grass/wasteland{
 	icon_state = "tall_grass_2";
@@ -52720,12 +52745,6 @@
 	icon_state = "plating"
 	},
 /area/f13/building/firestation)
-"ucS" = (
-/obj/structure/car/rubbish1,
-/turf/open/indestructible/ground/outside/road{
-	icon_state = "verticalinnermain1"
-	},
-/area/f13/wasteland/east)
 "ucT" = (
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "verticaloutermain1"
@@ -52888,6 +52907,15 @@
 	icon_state = "floordirtysolid"
 	},
 /area/f13/brotherhood)
+"uky" = (
+/obj/structure/table_frame,
+/obj/effect/decal/cleanable/glass,
+/obj/item/shard,
+/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite{
+	icon_state = "showroomfloor";
+	name = "tile"
+	},
+/area/f13/building)
 "ukz" = (
 /obj/structure/car/rubbish2,
 /turf/open/indestructible/ground/outside/road{
@@ -53057,12 +53085,6 @@
 	icon_state = "darkrusty"
 	},
 /area/f13/building/firestation)
-"upd" = (
-/obj/effect/overlay/desert/sonora/edge/corner{
-	dir = 4
-	},
-/turf/open/floor/plating/dirt,
-/area/f13/wasteland/train)
 "upn" = (
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "verticalleftborderleft1"
@@ -54011,6 +54033,12 @@
 /obj/machinery/mineral/wasteland_vendor/special,
 /turf/open/floor/plating/f13/inside,
 /area/f13/building)
+"uRz" = (
+/turf/open/indestructible/ground/outside/ruins{
+	dir = 1;
+	icon_state = "rubblecorner"
+	},
+/area/f13/wasteland/nanotrasen)
 "uRG" = (
 /obj/item/stack/sheet/mineral/wood,
 /obj/effect/decal/cleanable/dirt{
@@ -55324,14 +55352,6 @@
 /obj/machinery/light/floor,
 /turf/open/floor/plasteel/white/side,
 /area/f13/brotherhood)
-"vEF" = (
-/obj/effect/decal/marking{
-	icon_state = "doubleverticalbottom"
-	},
-/turf/open/indestructible/ground/outside/road{
-	icon_state = "verticalinnermain1"
-	},
-/area/f13/wasteland/train)
 "vEX" = (
 /obj/structure/simple_door/wood,
 /turf/open/floor/f13/wood,
@@ -56314,12 +56334,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13,
 /area/f13/building)
-"wkn" = (
-/obj/structure/car,
-/turf/open/indestructible/ground/outside/road{
-	icon_state = "horizontalbottombordertop0"
-	},
-/area/f13/wasteland/museum)
 "wkv" = (
 /obj/structure/decoration/warning{
 	name = "WARNING: NO MANS LAND AHEAD PVP ZONE";
@@ -56572,6 +56586,12 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/building/mall)
+"wpS" = (
+/obj/structure/car,
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "horizontalinnermain1"
+	},
+/area/f13/wasteland/east)
 "wpY" = (
 /obj/machinery/vending/games,
 /turf/open/floor/carpet,
@@ -56943,8 +56963,9 @@
 /turf/open/floor/plasteel/freezer,
 /area/f13/brotherhood/leisure)
 "wCJ" = (
-/obj/effect/turf_decal/weather/dirt,
-/turf/open/indestructible/ground/outside/water,
+/turf/open/indestructible/ground/outside/desert{
+	icon_state = "wasteland33"
+	},
 /area/f13/wasteland/train)
 "wCK" = (
 /obj/machinery/workbench,
@@ -56954,12 +56975,12 @@
 /area/f13/building)
 "wCN" = (
 /obj/effect/decal/marking{
-	icon_state = "doublevertical"
+	icon_state = "doubleverticalcorroded"
 	},
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "verticalinnermain1"
 	},
-/area/f13/wasteland/east)
+/area/f13/wasteland/train)
 "wCS" = (
 /obj/structure/table/reinforced,
 /obj/effect/decal/cleanable/dirt,
@@ -57059,11 +57080,6 @@
 	icon_state = "bluerustysolid"
 	},
 /area/f13/building/museum)
-"wGk" = (
-/turf/open/indestructible/ground/outside/desert{
-	icon_state = "wasteland32"
-	},
-/area/f13/ruins)
 "wGr" = (
 /obj/structure/chair,
 /obj/effect/decal/cleanable/dirt,
@@ -57420,11 +57436,13 @@
 	},
 /area/f13/building/hospital)
 "wPb" = (
-/obj/structure/barricade/sandbags,
-/turf/open/indestructible/ground/outside/road{
-	icon_state = "verticalinnermain0"
+/obj/effect/decal/marking{
+	icon_state = "doubleverticaltop"
 	},
-/area/f13/wasteland/hospital)
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "verticalinnermain2"
+	},
+/area/f13/wasteland/east)
 "wPl" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/poddoor/shutters{
@@ -57772,12 +57790,6 @@
 /obj/item/clothing/under/f13/raiderrags,
 /turf/open/floor/f13,
 /area/f13/building)
-"xad" = (
-/obj/effect/turf_decal/weather/dirt{
-	dir = 9
-	},
-/turf/open/indestructible/ground/outside/water,
-/area/f13/wasteland/train)
 "xaj" = (
 /obj/structure/simple_door/glass,
 /turf/open/floor/f13{
@@ -57877,14 +57889,6 @@
 	icon_state = "darkrusty"
 	},
 /area/f13/building/massfusion)
-"xcq" = (
-/obj/effect/decal/marking{
-	icon_state = "doubleverticalbottom"
-	},
-/turf/open/indestructible/ground/outside/road{
-	icon_state = "verticalinnermain1"
-	},
-/area/f13/wasteland/east)
 "xcF" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_x = -28
@@ -58565,6 +58569,14 @@
 	icon_state = "outermaincornerouter"
 	},
 /area/f13/wasteland/museum)
+"xzI" = (
+/obj/effect/decal/marking{
+	icon_state = "dottedverticaldegraded"
+	},
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "verticalinnermain1"
+	},
+/area/f13/wasteland/east)
 "xzK" = (
 /obj/effect/turf_decal/weather/dirt{
 	dir = 6
@@ -58892,11 +58904,6 @@
 	icon_state = "horizontaloutermain2"
 	},
 /area/f13/wasteland/firestation)
-"xIa" = (
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "outerpavementcorner"
-	},
-/area/f13/wasteland/train)
 "xIY" = (
 /turf/open/floor/wood/wood_worn,
 /area/f13/city/bighorn)
@@ -59251,7 +59258,7 @@
 "xTP" = (
 /obj/effect/decal/remains/human,
 /turf/open/indestructible/ground/outside/road{
-	icon_state = "verticalleftborderright0"
+	icon_state = "verticalleftborderright1"
 	},
 /area/f13/wasteland/east)
 "xUm" = (
@@ -59336,6 +59343,11 @@
 	icon_state = "verticalinnermain0"
 	},
 /area/f13/wasteland/east)
+"xWR" = (
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "verticalleftborderright1"
+	},
+/area/f13/wasteland/heaven)
 "xXf" = (
 /obj/structure/fence/wooden{
 	dir = 4
@@ -59405,7 +59417,7 @@
 "xZj" = (
 /obj/structure/barricade/wooden,
 /turf/open/indestructible/ground/outside/road{
-	icon_state = "verticalleftborderright0"
+	icon_state = "verticalleftborderright1"
 	},
 /area/f13/wasteland/east)
 "xZo" = (
@@ -67730,7 +67742,7 @@ mSJ
 ozv
 lVH
 lVH
-lVH
+kXR
 lVH
 lVH
 vXM
@@ -70813,7 +70825,7 @@ lVH
 lVH
 lVH
 lVH
-lVH
+kXR
 lVH
 lVH
 lVH
@@ -71833,7 +71845,7 @@ lVH
 lVH
 lVH
 lVH
-lVH
+kXR
 lVH
 lVH
 lVH
@@ -72606,7 +72618,7 @@ lVH
 lVH
 lVH
 lVH
-lVH
+kXR
 lVH
 lVH
 lVH
@@ -74191,7 +74203,7 @@ jZx
 pWU
 pWU
 pWU
-lEf
+bnS
 mGE
 dtk
 mGE
@@ -74607,7 +74619,7 @@ czi
 czi
 czi
 nyd
-iTb
+uRz
 gDC
 czi
 baD
@@ -76192,7 +76204,7 @@ axZ
 sdg
 sdg
 aMV
-dCh
+cJN
 aXW
 hqc
 hqc
@@ -77987,7 +77999,7 @@ hqc
 hqc
 hqc
 cps
-jiT
+mkR
 cqZ
 hqc
 hqc
@@ -78502,7 +78514,7 @@ cqZ
 cqZ
 cqZ
 cqZ
-sYy
+haL
 hqc
 hqc
 nTX
@@ -79000,8 +79012,8 @@ tCl
 tCl
 gvW
 gvW
-ofD
-ofD
+xWR
+xWR
 vxU
 pFj
 pFj
@@ -81480,7 +81492,7 @@ afz
 apZ
 ajM
 ajM
-wGk
+gRN
 ajM
 ajM
 afz
@@ -90042,7 +90054,7 @@ ttk
 ttk
 aTZ
 ttk
-onm
+mvK
 mvK
 lvp
 aVK
@@ -90299,7 +90311,7 @@ aTm
 cFy
 wzC
 wzC
-aUI
+wzC
 wzC
 wzC
 aFu
@@ -90556,7 +90568,7 @@ ifg
 ifg
 lgj
 kWn
-aMe
+iWF
 kWn
 akG
 csR
@@ -90901,7 +90913,7 @@ jns
 jns
 jns
 jns
-qgl
+agA
 jns
 jns
 jns
@@ -91172,7 +91184,7 @@ jns
 jns
 jns
 jns
-qgl
+agA
 jns
 jns
 jns
@@ -91410,7 +91422,7 @@ kHQ
 jns
 jns
 jns
-qgl
+agA
 jns
 jns
 jns
@@ -91418,11 +91430,11 @@ jns
 jns
 jns
 jns
-qgl
+agA
 jns
 jns
 jns
-qgl
+agA
 jns
 jns
 jns
@@ -91872,13 +91884,13 @@ blg
 faP
 dqz
 eML
-fKS
+hkf
 tCl
 eZr
 blg
 blg
 rVL
-mea
+ifU
 lIs
 blg
 rgz
@@ -92654,7 +92666,7 @@ bng
 rqF
 xeS
 bcJ
-lwR
+kba
 ruV
 aod
 pXv
@@ -93162,7 +93174,7 @@ ahQ
 blg
 blg
 blg
-pYf
+dGd
 bng
 avO
 rqF
@@ -93674,7 +93686,7 @@ oQn
 blg
 nlf
 bkO
-hWj
+itD
 qnu
 rEP
 bng
@@ -93931,7 +93943,7 @@ rTS
 blg
 nlf
 blg
-gPD
+oPv
 rEP
 blT
 avO
@@ -94230,7 +94242,7 @@ jns
 kpx
 jns
 jns
-qgl
+agA
 jns
 jns
 mpj
@@ -94446,7 +94458,7 @@ blg
 nlf
 blg
 spL
-kXR
+uky
 vvB
 bnh
 kKH
@@ -94494,7 +94506,7 @@ mpj
 jns
 ckj
 jns
-qgl
+agA
 jns
 jns
 jns
@@ -95515,7 +95527,7 @@ ftc
 doZ
 rOO
 uVJ
-mbs
+cqC
 ubS
 tjF
 mpj
@@ -95772,7 +95784,7 @@ ftc
 jUo
 qpD
 xZN
-mbs
+cqC
 eGZ
 tjF
 mpj
@@ -96029,7 +96041,7 @@ ftc
 jUo
 qpD
 xZN
-mbs
+cqC
 irj
 tjF
 mpj
@@ -96037,7 +96049,7 @@ jns
 jns
 jns
 jns
-qgl
+agA
 jns
 jns
 epY
@@ -96286,7 +96298,7 @@ ftc
 jUo
 qpD
 xZN
-mbs
+cqC
 kBk
 tjF
 tmP
@@ -96502,7 +96514,7 @@ djC
 cry
 oBE
 aqQ
-mOP
+lzK
 xyU
 kSp
 blg
@@ -96543,7 +96555,7 @@ ftc
 lPx
 qpD
 xZN
-mbs
+cqC
 kBk
 sCO
 dZK
@@ -96800,7 +96812,7 @@ ldz
 sUr
 qpD
 ukz
-mbs
+cqC
 kBk
 wdP
 swq
@@ -97057,7 +97069,7 @@ hDo
 bGA
 qpD
 qOB
-wkn
+frP
 kBk
 swq
 swq
@@ -97314,7 +97326,7 @@ izZ
 izZ
 xZN
 xZN
-mbs
+cqC
 kBk
 wdP
 epY
@@ -97571,7 +97583,7 @@ kSu
 kSu
 xZN
 xZN
-mbs
+cqC
 kBk
 swq
 epY
@@ -97828,7 +97840,7 @@ xUU
 xQj
 qpD
 iva
-mbs
+cqC
 kBk
 wdP
 epY
@@ -98085,7 +98097,7 @@ hDo
 bGA
 qpD
 jOi
-mbs
+cqC
 kBk
 wdP
 epY
@@ -98309,8 +98321,8 @@ hmz
 hmz
 hmz
 hmz
-eHm
-eHm
+hlr
+hlr
 crU
 cvo
 rmP
@@ -98342,7 +98354,7 @@ xZN
 xZN
 xZN
 jOi
-mbs
+cqC
 kBk
 swq
 epY
@@ -98599,7 +98611,7 @@ xZN
 iva
 iva
 jOi
-mbs
+cqC
 kBk
 swq
 epY
@@ -98856,7 +98868,7 @@ jOi
 ooV
 tJp
 jOi
-mbs
+cqC
 bgH
 wdP
 epY
@@ -99113,7 +99125,7 @@ bxl
 vvX
 xiA
 vVc
-mbs
+cqC
 kBk
 kbY
 epY
@@ -99370,7 +99382,7 @@ jOi
 kzt
 kzt
 kzt
-mbs
+cqC
 bGz
 wdP
 gEi
@@ -99627,7 +99639,7 @@ qIh
 xZN
 xZN
 xZN
-mbs
+cqC
 cKl
 gTC
 gEi
@@ -99884,7 +99896,7 @@ xZN
 xZN
 jOi
 xZN
-mbs
+cqC
 cKl
 ctF
 epY
@@ -100141,7 +100153,7 @@ qIh
 xZN
 xZN
 xZN
-mbs
+cqC
 cKl
 reb
 epY
@@ -102066,7 +102078,7 @@ twF
 twF
 tGt
 pXz
-wPb
+pMm
 pMm
 tGt
 oov
@@ -102323,7 +102335,7 @@ hHa
 hHa
 hHa
 uhE
-hVG
+jtW
 jtW
 itN
 oov
@@ -103647,7 +103659,7 @@ aNj
 azI
 kFN
 xHG
-weM
+xON
 uIo
 uIo
 nvp
@@ -105190,7 +105202,7 @@ aNC
 kFN
 rTO
 vjd
-hUc
+oxQ
 hPs
 uKF
 aQL
@@ -105447,7 +105459,7 @@ dSM
 dSM
 hWv
 aPu
-hUc
+oxQ
 hPs
 rjx
 qum
@@ -105704,7 +105716,7 @@ aMq
 orb
 xHG
 uYQ
-hUc
+oxQ
 hPs
 oeZ
 vGC
@@ -105961,7 +105973,7 @@ aMq
 orb
 aPe
 weM
-hUc
+oxQ
 hPs
 dWw
 vGC
@@ -106732,7 +106744,7 @@ aMq
 orb
 mPP
 weM
-hUc
+oxQ
 cwW
 lAx
 uZd
@@ -106989,7 +107001,7 @@ aMq
 orb
 mPP
 weM
-hUc
+oxQ
 uIo
 cny
 rZr
@@ -106998,38 +107010,38 @@ cny
 cny
 cny
 cny
+auZ
+auZ
+auZ
+fre
+fre
+fre
+fre
+fre
+auZ
+auZ
 kdL
 kdL
 kdL
-kdL
-kdL
-kdL
-kdL
-kdL
-kdL
-kdL
-kdL
-kdL
-kdL
-kdL
+auZ
 xTP
+auZ
+auZ
 kdL
 kdL
 kdL
-kdL
-kdL
-kdL
-kdL
-kdL
-kdL
-dpD
+auZ
+auZ
+auZ
+auZ
+mjA
 xZj
-xPu
-xPu
-xPu
-xPu
-xPu
-xPu
+auZ
+auZ
+auZ
+fre
+fre
+fre
 fUe
 cpx
 qRe
@@ -107246,47 +107258,47 @@ aMq
 orb
 mPP
 weM
-hUc
+oxQ
 uhG
 fLw
 sUU
 fLw
 fLw
-fLw
-fLw
+ylr
+ylr
 iMm
+jMr
+jMr
+jMr
+jMr
+jMr
+jMr
+jMr
+jMr
+jMr
+jMr
+jMr
 xPu
-xPu
-xPu
-xPu
-xPu
-xPu
-xPu
-xPu
-xPu
-xPu
-xPu
-xPu
-xPu
-xPu
-xPu
-xPu
-xPu
-xPu
-xPu
+jMr
+jMr
+jMr
+jMr
+jMr
+jMr
+jMr
 xPu
 xPu
 aWS
 vBH
 xPu
-xPu
-xPu
-aDD
-xPu
-aCM
-xPu
+jMr
+jMr
+wPr
+jbm
+elO
+jbm
 peL
-xPu
+jbm
 fUe
 cpx
 cpx
@@ -107510,40 +107522,40 @@ gzl
 qZM
 qZM
 qZM
-qZM
+bBY
 lSQ
+dnw
+dnw
+wNn
+wNn
+dnw
+dnw
+dnw
+sLz
+dnw
+dnw
+dnw
+dnw
+wNn
+wNn
+wNn
+wNn
+dnw
+dnw
+dnw
 sLz
 sLz
 sLz
 sLz
-sLz
-sLz
-sLz
-sLz
-sLz
-sLz
-sLz
-sLz
-sLz
-sLz
-sLz
-sLz
-sLz
-sLz
-sLz
-sLz
-sLz
-sLz
-sLz
-sLz
+dnw
 aIQ
-sLz
-xPu
-xPu
-xPu
-xPu
-xPu
-xPu
+dnw
+dnw
+dnw
+wNn
+wNn
+wNn
+wNn
 fUe
 cpx
 cpx
@@ -108017,7 +108029,7 @@ cGc
 fLw
 aIY
 vjd
-hUc
+oxQ
 uIo
 uKF
 xRA
@@ -108274,7 +108286,7 @@ cQz
 fLw
 fLw
 xON
-hUc
+oxQ
 uhG
 uKF
 qum
@@ -108531,7 +108543,7 @@ xpr
 fLw
 gko
 weM
-hUc
+oxQ
 uIo
 oeZ
 vGC
@@ -108573,14 +108585,14 @@ cpx
 pkJ
 eVx
 wTj
-oUk
+dxB
 pxv
 pxv
 dYH
+eiK
+eiK
+eiK
 ahQ
-nlf
-xPu
-xPu
 pMY
 agk
 beq
@@ -108788,7 +108800,7 @@ eaC
 fLw
 fLw
 weM
-hUc
+oxQ
 uIo
 txY
 whp
@@ -108830,14 +108842,14 @@ hop
 nBP
 vJu
 nAt
-cvo
-xPu
+muJ
+eiK
 oXJ
 eiK
-xPu
-aWS
-xPu
-xPu
+eiK
+wpS
+rGi
+ahQ
 pMY
 agk
 ain
@@ -109045,7 +109057,7 @@ dnv
 fLw
 cwW
 weM
-hUc
+oxQ
 uhG
 txY
 xRA
@@ -109087,14 +109099,14 @@ vJu
 vJu
 aBP
 nAt
-cvo
-xPu
-xPu
-xPu
-xPu
-xPu
-xPu
-xPu
+muJ
+eiK
+eiK
+eiK
+rGi
+rGi
+rGi
+ahQ
 pMY
 agk
 ber
@@ -109345,13 +109357,13 @@ esK
 vJu
 nAt
 cvo
-xPu
-xPu
-xPu
-xPu
-xPu
-xPu
-xPu
+rGi
+rGi
+rGi
+rGi
+rGi
+rGi
+ahQ
 pMY
 agk
 bes
@@ -109602,13 +109614,13 @@ esK
 esK
 nAt
 cvo
-xWg
-xPu
-xPu
-xWg
-xPu
+hfi
+rGi
+rGi
+hfi
+rGi
 peL
-xPu
+ahQ
 pMY
 agk
 bet
@@ -109816,7 +109828,7 @@ aMq
 tkC
 hWv
 weM
-hUc
+oxQ
 uIo
 uKF
 whp
@@ -109859,13 +109871,13 @@ aae
 esK
 nAt
 cvo
-xPu
-xPu
-xPu
-xPu
-xPu
-xPu
-xPu
+rmP
+rmP
+rGi
+rmP
+rGi
+rmP
+ahQ
 pMY
 agk
 afS
@@ -110073,7 +110085,7 @@ odv
 tkC
 hWv
 weM
-hUc
+oxQ
 uIo
 uKF
 xRA
@@ -110116,13 +110128,13 @@ aae
 vJu
 nAt
 cvo
-xPu
-xPu
-xPu
+rmP
+rmP
+rmP
 mZK
-xPu
-xPu
-xPu
+rmP
+rmP
+ahQ
 pMY
 agk
 beu
@@ -110330,7 +110342,7 @@ xAw
 xRA
 xHG
 weM
-hUc
+oxQ
 uIo
 uKF
 xRA
@@ -110373,13 +110385,13 @@ aae
 esK
 nAt
 cvo
-xPu
-xPu
-xPu
-xPu
-xPu
-xPu
-xPu
+rmP
+rmP
+rmP
+rmP
+rmP
+rmP
+ahQ
 pMY
 agk
 wAf
@@ -110587,7 +110599,7 @@ aMq
 tkC
 mPP
 weM
-hUc
+oxQ
 uIo
 uKF
 xRA
@@ -110635,8 +110647,8 @@ sLz
 sLz
 sLz
 sLz
-xPu
-xPu
+rmP
+ahQ
 pMY
 agk
 jTY
@@ -110844,7 +110856,7 @@ wEg
 mYw
 aPk
 cvo
-rmP
+rGi
 tkv
 pMY
 gpS
@@ -110893,7 +110905,7 @@ qLf
 qLf
 wnj
 cvo
-xPu
+ahQ
 pMY
 agk
 bex
@@ -111150,7 +111162,7 @@ vJu
 hmz
 nAt
 cvo
-xPu
+ahQ
 pMY
 ail
 ahj
@@ -111407,7 +111419,7 @@ hmz
 hmz
 nAt
 cvo
-xPu
+ahQ
 pMY
 agk
 agk
@@ -111664,7 +111676,7 @@ hmz
 hmz
 nAt
 cvo
-xPu
+ahQ
 pMY
 vJu
 vJu
@@ -112122,7 +112134,7 @@ nAt
 cvo
 xPu
 pnc
-oPW
+fXN
 uWg
 xPu
 xPu
@@ -115776,7 +115788,7 @@ asX
 nwW
 ctV
 nAt
-dpL
+lOP
 ify
 agk
 afS
@@ -116033,7 +116045,7 @@ asX
 aKP
 oqY
 nAt
-dpL
+lOP
 ify
 afC
 afS
@@ -116290,7 +116302,7 @@ aKP
 aKP
 qiy
 nAt
-dpL
+lOP
 ify
 agk
 agk
@@ -116547,7 +116559,7 @@ asX
 sNP
 tRi
 nAt
-dpL
+lOP
 pgy
 kdL
 ufd
@@ -116644,11 +116656,11 @@ aae
 aae
 aae
 afn
-elO
-mHP
+rMv
+ohZ
 lTe
 nkd
-elO
+rMv
 aae
 aae
 aae
@@ -116804,7 +116816,7 @@ bgI
 aKP
 aKP
 nAt
-dpL
+lOP
 pgy
 jMr
 jMr
@@ -116902,10 +116914,10 @@ aae
 aae
 aae
 afn
-elO
+rMv
 xpV
 nkd
-elO
+rMv
 afn
 aae
 aae
@@ -117061,7 +117073,7 @@ bgI
 oNY
 bbd
 nAt
-dpL
+lOP
 pgy
 xPu
 jMr
@@ -117159,11 +117171,11 @@ aae
 aae
 aae
 ahz
-elO
+rMv
 xpV
 lTe
-bmb
-elO
+rhY
+rMv
 aae
 aae
 aae
@@ -117318,7 +117330,7 @@ bgI
 oNY
 bbd
 nAt
-dpL
+lOP
 pgy
 jMr
 jMr
@@ -117417,10 +117429,10 @@ aae
 aae
 aae
 afn
-mHP
+ohZ
 lTe
-nfS
-elO
+ekq
+rMv
 afn
 aae
 aae
@@ -117575,7 +117587,7 @@ asX
 aKP
 aKP
 nAt
-dpL
+lOP
 pgy
 jMr
 jMr
@@ -117675,10 +117687,10 @@ aae
 aae
 afn
 qKg
-bOD
-wCJ
+lCB
+mdh
 qKg
-cqQ
+dip
 aae
 ijB
 qOL
@@ -117722,7 +117734,7 @@ qOL
 qOL
 qOL
 qOL
-ehQ
+wCJ
 cpx
 cpx
 cpx
@@ -117932,12 +117944,12 @@ aae
 aae
 qKg
 qKg
-bOD
-wCJ
+lCB
+mdh
 qKg
 qKg
 qKg
-qpz
+nfu
 qOL
 qOL
 qOL
@@ -118189,13 +118201,13 @@ aae
 aae
 fWm
 qKg
-bOD
+lCB
 gNG
-kJM
+eOb
 qKg
-cqQ
-qpz
-xIa
+dip
+nfu
+prm
 iBT
 iBT
 iBT
@@ -118446,9 +118458,9 @@ aaf
 aaf
 qKg
 qKg
-bOD
+lCB
 gNG
-wCJ
+mdh
 qKg
 qKg
 ijB
@@ -118692,65 +118704,65 @@ aaa
 aag
 wkv
 hKY
-dip
-dip
-dip
-dip
-dip
-dip
+dNW
+dNW
+dNW
+dNW
+dNW
+dNW
 hKY
 hKY
 acL
 qKg
-cqQ
-bOD
+dip
+lCB
 gNG
-wCJ
+mdh
 fWm
 qKg
-fBg
+qpz
 lQs
 lQs
 lQs
 lQs
 lQs
 lQs
-jmf
-jmf
-jmf
-jmf
+moJ
+moJ
+moJ
+moJ
 lQs
 lQs
 lQs
 lQs
 lQs
-jmf
-jmf
-jmf
-jmf
-jmf
-jmf
-jmf
-jmf
-jmf
-jmf
+moJ
+moJ
+moJ
+moJ
+moJ
+moJ
+moJ
+moJ
+moJ
+moJ
 lQs
 lQs
 lQs
 lQs
-jmf
-jmf
-jmf
-jmf
-jmf
-jmf
-jmf
+moJ
+moJ
+moJ
+moJ
+moJ
+moJ
+moJ
 lQs
 lQs
 lQs
 lQs
 lQs
-jmf
+moJ
 auZ
 auZ
 auZ
@@ -118950,10 +118962,10 @@ oGu
 aas
 aas
 aas
-mdh
-ais
-mdh
-mdh
+fKM
+hVG
+fKM
+fKM
 aas
 aas
 aas
@@ -118973,10 +118985,10 @@ rHm
 rHm
 rHm
 rHm
-nfu
-moJ
-moJ
-nfu
+jmf
+aIA
+aIA
+jmf
 rHm
 rHm
 rHm
@@ -118984,10 +118996,10 @@ rHm
 rHm
 rHm
 rHm
-nfu
+jmf
 wLX
-nfu
-nfu
+jmf
+jmf
 rHm
 rHm
 rHm
@@ -118997,11 +119009,11 @@ rHm
 rHm
 rHm
 rHm
-nfu
-moJ
-moJ
-nfu
-nfu
+jmf
+aIA
+aIA
+jmf
+jmf
 rHm
 rHm
 rHm
@@ -119206,10 +119218,10 @@ aaa
 wiN
 aas
 aas
-mdh
-ais
-ais
-mdh
+fKM
+hVG
+hVG
+fKM
 aas
 aas
 aas
@@ -119224,41 +119236,41 @@ rHm
 rHm
 rHm
 rHm
-nfu
-nfu
-nfu
+jmf
+jmf
+jmf
 rHm
 rHm
 rHm
-nfu
-csY
-moJ
-nfu
-rHm
-rHm
-rHm
-rHm
-rHm
-rHm
-rHm
-nfu
-nfu
-moJ
-moJ
-nfu
-nfu
-nfu
+jmf
+iQT
+aIA
+jmf
 rHm
 rHm
 rHm
 rHm
 rHm
 rHm
-nfu
-nfu
-moJ
-nfu
-nfu
+rHm
+jmf
+jmf
+aIA
+aIA
+jmf
+jmf
+jmf
+rHm
+rHm
+rHm
+rHm
+rHm
+rHm
+jmf
+jmf
+aIA
+jmf
+jmf
 rHm
 rHm
 rHm
@@ -119319,7 +119331,7 @@ xPu
 xPu
 xPu
 xPu
-otr
+rxV
 jMr
 jMr
 jMr
@@ -119463,11 +119475,11 @@ aaa
 xwV
 aas
 aas
-mdh
-ais
-ais
-mdh
-mdh
+fKM
+hVG
+hVG
+fKM
+fKM
 aas
 aas
 aas
@@ -119477,34 +119489,34 @@ rHm
 rHm
 rHm
 rHm
-nfu
-nfu
-nfu
-nfu
-moJ
-moJ
-nfu
+jmf
+jmf
+jmf
+jmf
+aIA
+aIA
+jmf
 rHm
 rHm
 rHm
-nfu
-nfu
-nfu
-moJ
-nfu
+jmf
+jmf
+jmf
+aIA
+jmf
 rHm
 rHm
 rHm
 rHm
 rHm
 rHm
-nfu
-nfu
-moJ
-csY
-moJ
-nfu
-nfu
+jmf
+jmf
+aIA
+iQT
+aIA
+jmf
+jmf
 rHm
 qsM
 rHm
@@ -119512,12 +119524,12 @@ rHm
 rHm
 rHm
 rHm
-nfu
-nfu
-moJ
-moJ
-nfu
-nfu
+jmf
+jmf
+aIA
+aIA
+jmf
+jmf
 rHm
 rHm
 rHm
@@ -119557,7 +119569,7 @@ xPu
 jMr
 jMr
 jMr
-otr
+rxV
 jMr
 xPu
 xPu
@@ -119721,13 +119733,13 @@ xwV
 acA
 aaz
 aaz
-tGL
-tGL
-aPZ
-aPZ
-qQl
-qQl
-mdh
+lDh
+lDh
+rlH
+rlH
+kJa
+kJa
+fKM
 aas
 rHm
 iwV
@@ -119736,86 +119748,86 @@ rXG
 rHm
 dJf
 hFW
-hMa
+jgP
+tfM
 fEW
-cZr
-kCa
-mzW
-fLM
-sCs
-qsM
-jdf
-rXG
-rXG
-fEW
-mzW
-fLM
-sCs
-iwV
-rXG
-rXG
-iwV
-iwV
-mzW
-fEW
-fEW
-kCa
-cZr
-jdf
-jdf
-rXG
-rXG
-fEW
-fEW
-fEW
-rXG
-iwV
-vEF
-mqr
-mzW
-fEW
-rWs
-qsM
-iwV
-rXG
-rXG
-aXv
-aXv
+lMd
 wCN
-aIA
-ghv
+fLM
+sCs
+qsM
+jdf
+rXG
+rXG
+tfM
+wCN
+fLM
+sCs
+iwV
+rXG
+rXG
+iwV
+iwV
+wCN
+tfM
+tfM
+lMd
+fEW
+jdf
+jdf
+rXG
+rXG
+tfM
+tfM
+tfM
+rXG
+iwV
+dwc
+qnS
+wCN
+tfM
+qgl
+qsM
+iwV
+rXG
+rXG
+aXv
+aXv
+nzi
+dpL
+ais
 acH
 acH
 aXv
-tGc
+mzW
 vdf
 ayD
 aXv
-wCN
-wCN
-ftH
-ftH
-aIA
+nzi
+nzi
+csY
+csY
+dpL
 agj
 agH
-aIA
-wCN
-wCN
-ftH
-ftH
-ghv
-aIA
-aIA
+dpL
+nzi
+nzi
+csY
+csY
+ais
+dpL
+dpL
 acH
-wCN
-wCN
+nzi
+nzi
 aXv
 aXv
 aXv
-xcq
+eYN
 agH
-aIA
-wCN
+dpL
+nzi
 aXv
 acH
 xPu
@@ -119823,81 +119835,81 @@ xPu
 xPu
 afs
 aXv
-wCN
-cqC
-ftH
-wCN
-aIA
-xcq
+nzi
+mbs
+csY
+nzi
+dpL
+eYN
 agH
 aXv
 aXv
-wCN
-wCN
-wCN
-ghv
-tEP
-aIA
-tGc
-tGc
+nzi
+nzi
+nzi
+ais
+qVO
+dpL
+mzW
+mzW
 ayD
 aXv
 acH
-xcq
-agA
-aIA
+eYN
+iBX
+dpL
 aXv
-wCN
-wCN
-wCN
-aIA
+nzi
+nzi
+nzi
+dpL
 acH
-wCN
-wCN
-ftH
-aIA
-xcq
-agA
-aIA
-wCN
+nzi
+nzi
+csY
+dpL
+eYN
+iBX
+dpL
+nzi
 aXv
 acH
 aPM
 ayD
-iyd
-cqC
-ftH
-wCN
+xzI
+mbs
+csY
+nzi
 afs
 aXv
 aXv
-aIA
+dpL
 agj
 agH
-aIA
-wCN
-wCN
+dpL
+nzi
+nzi
 aXv
 aXv
-wCN
-wCN
-wCN
-lZY
-kPX
-aIA
-wCN
-wCN
+nzi
+nzi
+nzi
+iUW
+wPb
+dpL
+nzi
+nzi
 acH
 xPu
 xPu
 xPu
-cqC
-ucS
-wCN
+mbs
+ljD
+nzi
 afs
-otr
-wCN
-aIA
+rxV
+nzi
+dpL
 agj
 agH
 aet
@@ -119980,11 +119992,11 @@ aas
 aas
 aaS
 aas
-ais
-ais
-mdh
-mdh
-mdh
+hVG
+hVG
+fKM
+fKM
+fKM
 aas
 rHm
 rHm
@@ -119995,8 +120007,8 @@ rHm
 rHm
 rHm
 rHm
-nfu
-nfu
+jmf
+jmf
 rHm
 rHm
 rHm
@@ -120005,31 +120017,31 @@ rHm
 rHm
 rHm
 rHm
-nfu
-nfu
-nfu
-nfu
-nfu
+jmf
+jmf
+jmf
+jmf
+jmf
 rHm
 rHm
 rHm
 rHm
-nfu
-nfu
-nfu
+jmf
+jmf
+jmf
 rHm
 rHm
 rHm
 rHm
 rHm
-nfu
-moJ
-nfu
+jmf
+aIA
+jmf
 rHm
 rHm
 rHm
-nfu
-nfu
+jmf
+jmf
 rHm
 rHm
 rHm
@@ -120235,11 +120247,11 @@ lew
 aas
 aas
 aas
-mdh
-mdh
-mdh
-mdh
-mdh
+fKM
+fKM
+fKM
+fKM
+fKM
 aas
 aas
 aas
@@ -120262,11 +120274,11 @@ rHm
 rHm
 rHm
 rHm
-moJ
-moJ
-moJ
-nfu
-nfu
+aIA
+aIA
+aIA
+jmf
+jmf
 rHm
 qsM
 rHm
@@ -120277,19 +120289,19 @@ rHm
 rHm
 rHm
 rHm
-nfu
-moJ
-csY
-nfu
-nfu
+jmf
+aIA
+iQT
+jmf
+jmf
 rHm
 rHm
 rHm
 rHm
-nfu
-nfu
-nfu
-nfu
+jmf
+jmf
+jmf
+jmf
 rHm
 rHm
 rHm
@@ -120319,7 +120331,7 @@ aWS
 xPu
 jMr
 xPu
-otr
+rxV
 jMr
 jMr
 jMr
@@ -120336,8 +120348,8 @@ xPu
 xPu
 jMr
 jMr
-otr
-otr
+rxV
+rxV
 jMr
 jMr
 xPu
@@ -120374,7 +120386,7 @@ xPu
 xPu
 lRq
 lRq
-otr
+rxV
 jMr
 jMr
 xPu
@@ -120493,9 +120505,9 @@ aas
 aas
 aas
 aas
-mdh
-mdh
-mdh
+fKM
+fKM
+fKM
 aas
 aas
 aas
@@ -120517,11 +120529,11 @@ jmh
 rHm
 rHm
 rHm
-nfu
-nfu
-moJ
-csY
-nfu
+jmf
+jmf
+aIA
+iQT
+jmf
 xTs
 rHm
 rHm
@@ -120534,20 +120546,20 @@ rHm
 rHm
 rHm
 rHm
-nfu
-nfu
+jmf
+jmf
 rHm
 rHm
 rHm
 rHm
 rHm
 rHm
-nfu
-nfu
-nfu
-nfu
-nfu
-nfu
+jmf
+jmf
+jmf
+jmf
+jmf
+jmf
 rHm
 rHm
 xPu
@@ -120748,10 +120760,10 @@ aaa
 aag
 mfk
 aao
-nzi
-nzi
-nzi
-nzi
+lvB
+lvB
+lvB
+lvB
 aao
 aao
 aao
@@ -120759,26 +120771,26 @@ aao
 acL
 fWm
 qKg
-bOD
+lCB
 gNG
-nWK
-cqQ
+qjv
+dip
 qKg
-fBg
+qpz
 fnd
 fnd
-lgq
-lgq
-lgq
+aUI
+aUI
+aUI
 fnd
 fnd
-lgq
-lgq
-lgq
-lgq
-lgq
-lgq
-lgq
+aUI
+aUI
+aUI
+aUI
+aUI
+aUI
+aUI
 fnd
 fnd
 fnd
@@ -120788,22 +120800,22 @@ fnd
 fnd
 fnd
 fnd
-lgq
-lgq
-lgq
-lgq
-lgq
-lgq
+aUI
+aUI
+aUI
+aUI
+aUI
+aUI
 fnd
 fnd
 fnd
 fnd
 fnd
-lgq
-lgq
-lgq
-lgq
-lgq
+aUI
+aUI
+aUI
+aUI
+aUI
 fnd
 fnd
 fnd
@@ -121015,7 +121027,7 @@ aaf
 aaf
 aaf
 qKg
-xad
+kkj
 gNG
 brn
 qKg
@@ -121272,13 +121284,13 @@ aae
 aae
 qKg
 qKg
-bOD
+lCB
 gNG
-nWK
+qjv
 qKg
 qKg
-cqQ
-qpz
+dip
+nfu
 hHo
 lBv
 lBv
@@ -121528,14 +121540,14 @@ aae
 aae
 aae
 aae
-xad
+kkj
 gNG
-nWK
+qjv
 qKg
 qKg
 cbo
 qKg
-qpz
+nfu
 qOL
 qOL
 qOL
@@ -121786,8 +121798,8 @@ aae
 aae
 lTe
 lTe
-wCJ
-upd
+mdh
+gNv
 wOu
 wOu
 wOu
@@ -122086,10 +122098,10 @@ qOL
 qOL
 qOL
 qOL
-ehQ
+wCJ
 qOL
 qOL
-ehQ
+wCJ
 qOL
 qOL
 cpx

--- a/_maps/map_files/Pahrump-Sunset/RockSprings.dmm
+++ b/_maps/map_files/Pahrump-Sunset/RockSprings.dmm
@@ -9868,12 +9868,6 @@
 	icon_state = "bar"
 	},
 /area/f13/building)
-"jWm" = (
-/obj/item/mine/shrapnel{
-	alpha = 65
-	},
-/turf/open/indestructible/ground/outside/desert/harsh,
-/area/f13/wasteland/rocksprings)
 "jXf" = (
 /obj/effect/overlay/turfs/cliff{
 	dir = 4;
@@ -68095,7 +68089,7 @@ hgP
 hgP
 hgP
 hgP
-jWm
+hgP
 hgP
 hgP
 hgP
@@ -68859,7 +68853,7 @@ hgP
 hgP
 hgP
 hgP
-jWm
+hgP
 hgP
 hgP
 hgP
@@ -69624,7 +69618,6 @@ hgP
 hgP
 hgP
 hgP
-jWm
 hgP
 hgP
 hgP
@@ -69636,14 +69629,15 @@ hgP
 hgP
 hgP
 hgP
-jWm
 hgP
 hgP
 hgP
 hgP
 hgP
 hgP
-jWm
+hgP
+hgP
+hgP
 hgP
 hgP
 hgP
@@ -71439,7 +71433,7 @@ gCB
 hgP
 hgP
 hgP
-jWm
+hgP
 hgP
 hgP
 hgP
@@ -74088,7 +74082,7 @@ rTl
 hgP
 hgP
 hgP
-jWm
+hgP
 hgP
 hgP
 hgP
@@ -74279,7 +74273,7 @@ hgP
 hgP
 hgP
 hgP
-jWm
+hgP
 hgP
 hgP
 hgP
@@ -74331,7 +74325,7 @@ psz
 vTD
 hgP
 hgP
-jWm
+hgP
 hgP
 hgP
 hgP
@@ -74853,7 +74847,7 @@ hgP
 hgP
 hgP
 hgP
-jWm
+hgP
 hgP
 hgP
 hgP
@@ -75890,7 +75884,7 @@ hgP
 hgP
 hgP
 hgP
-jWm
+hgP
 hgP
 hgP
 hgP
@@ -76129,7 +76123,7 @@ hgP
 hgP
 hgP
 hgP
-jWm
+hgP
 hgP
 hgP
 hgP
@@ -76583,7 +76577,7 @@ hgP
 hgP
 hgP
 hgP
-jWm
+hgP
 hgP
 hgP
 hgP
@@ -76635,7 +76629,7 @@ aAf
 paT
 qWV
 hgP
-jWm
+hgP
 hgP
 hgP
 hgP
@@ -76668,7 +76662,7 @@ hgP
 hgP
 hgP
 hgP
-jWm
+hgP
 hgP
 hgP
 hgP
@@ -77104,7 +77098,7 @@ hgP
 hgP
 hgP
 hgP
-jWm
+hgP
 hgP
 hgP
 hgP
@@ -78120,7 +78114,7 @@ hgP
 hgP
 hgP
 hgP
-jWm
+hgP
 hgP
 hgP
 hgP
@@ -78464,7 +78458,7 @@ hgP
 hgP
 hgP
 hgP
-jWm
+hgP
 hgP
 hgP
 hgP
@@ -78639,7 +78633,7 @@ hgP
 hgP
 hgP
 hgP
-jWm
+hgP
 hgP
 hgP
 hgP
@@ -78729,7 +78723,7 @@ hgP
 hgP
 hgP
 hgP
-jWm
+hgP
 hgP
 hgP
 nzH
@@ -78953,7 +78947,7 @@ hgP
 hgP
 hgP
 hgP
-jWm
+hgP
 hgP
 pHb
 hgP
@@ -79643,7 +79637,7 @@ hgP
 hgP
 hgP
 hgP
-jWm
+hgP
 hgP
 hgP
 hgP
@@ -79674,7 +79668,7 @@ hgP
 kLZ
 hgP
 hgP
-jWm
+hgP
 hgP
 hgP
 hgP
@@ -79891,7 +79885,6 @@ nzH
 hgP
 hgP
 hgP
-jWm
 hgP
 hgP
 hgP
@@ -79908,7 +79901,8 @@ hgP
 hgP
 hgP
 hgP
-jWm
+hgP
+hgP
 hgP
 hgP
 hgP
@@ -79974,7 +79968,7 @@ nzH
 hgP
 hgP
 hgP
-jWm
+hgP
 hgP
 hgP
 hgP
@@ -80911,7 +80905,6 @@ hgP
 hgP
 hgP
 hgP
-jWm
 hgP
 hgP
 hgP
@@ -80942,7 +80935,8 @@ hgP
 hgP
 hgP
 hgP
-jWm
+hgP
+hgP
 hgP
 hgP
 lof
@@ -81960,7 +81954,7 @@ hgP
 hgP
 hgP
 hgP
-jWm
+hgP
 hgP
 hgP
 hgP
@@ -82200,14 +82194,14 @@ hgP
 hgP
 hgP
 hgP
-jWm
 hgP
 hgP
 hgP
 hgP
 hgP
 hgP
-jWm
+hgP
+hgP
 hgP
 hgP
 hgP
@@ -83251,7 +83245,7 @@ hgP
 hgP
 hgP
 hgP
-jWm
+hgP
 hgP
 hgP
 hgP
@@ -83772,7 +83766,7 @@ hgP
 hgP
 hgP
 hgP
-jWm
+hgP
 hgP
 hgP
 hgP
@@ -84526,7 +84520,7 @@ hgP
 hgP
 hgP
 hgP
-jWm
+hgP
 hgP
 hgP
 hgP
@@ -84773,7 +84767,7 @@ hgP
 hgP
 hgP
 hgP
-jWm
+hgP
 hgP
 hgP
 hgP
@@ -85818,7 +85812,7 @@ hgP
 hgP
 hgP
 hgP
-jWm
+hgP
 hgP
 hgP
 hgP

--- a/_maps/map_files/Pahrump-Sunset/Warren.dmm
+++ b/_maps/map_files/Pahrump-Sunset/Warren.dmm
@@ -96,7 +96,7 @@
 	name = "Warren AFB Exterior"
 	},
 /turf/open/indestructible/ground/outside/road{
-	icon_state = "horizontalinnermain0"
+	icon_state = "horizontalinnermain1"
 	},
 /area/f13/wasteland/warren)
 "aal" = (
@@ -1201,7 +1201,8 @@
 "bbS" = (
 /obj/effect/spawner/lootdrop/f13/junkspawners,
 /turf/open/indestructible/ground/outside/road{
-	icon_state = "horizontaltopborderbottom0"
+	dir = 8;
+	icon_state = "horizontaltopborderbottom2left"
 	},
 /area/f13/wasteland/warren)
 "bcb" = (
@@ -1695,7 +1696,7 @@
 	name = "Warren North"
 	},
 /turf/open/indestructible/ground/outside/road{
-	icon_state = "horizontalinnermain0"
+	icon_state = "verticalinnermain1"
 	},
 /area/f13/wasteland/warren)
 "bAq" = (
@@ -1896,6 +1897,12 @@
 "bKS" = (
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "verticaloutermain1"
+	},
+/area/f13/wasteland/warren)
+"bKW" = (
+/obj/structure/barricade/wooden,
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "verticalrightborderleft0"
 	},
 /area/f13/wasteland/warren)
 "bKX" = (
@@ -3088,6 +3095,16 @@
 /obj/effect/spawner/lootdrop/f13/junkspawners,
 /turf/open/indestructible/ground/outside/sidewalk,
 /area/f13/city)
+"cOK" = (
+/obj/structure/railing/wood{
+	dir = 8;
+	pixel_x = -3
+	},
+/obj/structure/barricade/sandbags,
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "verticalleftborderright2"
+	},
+/area/f13/wasteland/warren)
 "cPv" = (
 /obj/structure/fence{
 	dir = 4
@@ -3191,7 +3208,7 @@
 "cTQ" = (
 /obj/structure/wreck/trash/bus_door,
 /turf/open/indestructible/ground/outside/road{
-	icon_state = "horizontalinnermain0"
+	icon_state = "horizontalbottombordertop0"
 	},
 /area/f13/wasteland/ncr)
 "cUs" = (
@@ -3362,18 +3379,6 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/ncr)
-"dev" = (
-/obj/structure/railing/wood{
-	dir = 8;
-	pixel_x = -3
-	},
-/obj/item/mine/shrapnel{
-	alpha = 65
-	},
-/turf/open/indestructible/ground/outside/road{
-	icon_state = "verticalleftborderright2bottom"
-	},
-/area/f13/wasteland/warren)
 "deF" = (
 /obj/structure/window/fulltile/ruins/broken,
 /obj/effect/decal/cleanable/glass,
@@ -3583,12 +3588,10 @@
 /turf/open/floor/plating/rust,
 /area/f13/caves)
 "dou" = (
-/obj/item/mine/shrapnel{
-	alpha = 65
+/obj/structure/flora/grass/wasteland{
+	icon_state = "tall_grass_4"
 	},
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "verticalleftborderleft0"
-	},
+/turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland/warren)
 "doW" = (
 /obj/effect/decal/cleanable/dirt,
@@ -5160,12 +5163,6 @@
 	icon_state = "darkrustysolid"
 	},
 /area/f13/city)
-"eUM" = (
-/obj/item/mine/shrapnel{
-	alpha = 65
-	},
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland/warren)
 "eVc" = (
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "horizontalinnermain3"
@@ -5447,8 +5444,11 @@
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland/ncr)
 "fit" = (
+/obj/effect/decal/marking{
+	icon_state = "dottedverticalcorroded"
+	},
 /turf/open/indestructible/ground/outside/road{
-	icon_state = "verylittleshadowleft"
+	icon_state = "horizontaltopborderbottom2"
 	},
 /area/f13/wasteland/warren)
 "fiv" = (
@@ -5646,6 +5646,11 @@
 	},
 /turf/open/floor/plasteel/vault,
 /area/f13/ncr)
+"frg" = (
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "topshadowleft"
+	},
+/area/f13/wasteland/warren)
 "frw" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/energy/low,
@@ -5790,15 +5795,9 @@
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland/warren)
 "fxB" = (
-/obj/structure/railing/wood{
-	dir = 4;
-	pixel_x = 3
-	},
-/obj/item/mine/shrapnel{
-	alpha = 65
-	},
+/obj/structure/barricade/sandbags,
 /turf/open/indestructible/ground/outside/road{
-	icon_state = "verticalrightborderleft0"
+	icon_state = "verticalleftborderright2"
 	},
 /area/f13/wasteland/warren)
 "fxD" = (
@@ -6317,10 +6316,11 @@
 	},
 /area/f13/wasteland/ncr)
 "fYQ" = (
+/obj/structure/barricade/sandbags,
 /turf/open/indestructible/ground/outside/road{
-	icon_state = "hole"
+	icon_state = "verticalinnermain1"
 	},
-/area/f13/wasteland/ncr)
+/area/f13/wasteland/warren)
 "fYS" = (
 /obj/item/reagent_containers/glass/bottle/phosphorus{
 	pixel_x = 9;
@@ -6345,12 +6345,6 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/city)
-"fZh" = (
-/obj/structure/table/wood/settler,
-/turf/open/indestructible/ground/outside/ruins{
-	icon_state = "rubblepillar"
-	},
-/area/f13/wasteland/warren)
 "fZl" = (
 /turf/closed/wall/f13/tunnel,
 /area/f13/wasteland/ncr)
@@ -6632,14 +6626,6 @@
 	icon_state = "whitegreenrustychess"
 	},
 /area/f13/city)
-"gmO" = (
-/obj/item/mine/shrapnel{
-	alpha = 65
-	},
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "verticalrightborderright0"
-	},
-/area/f13/wasteland/warren)
 "gns" = (
 /obj/structure/table/reinforced,
 /obj/machinery/cell_charger,
@@ -6654,10 +6640,11 @@
 /turf/closed/mineral/random/low_chance,
 /area/f13/caves)
 "gnT" = (
-/turf/open/indestructible/ground/outside/road{
-	icon_state = "horizontalinnermain1"
+/obj/effect/decal/marking,
+/turf/open/floor/plating/f13/outside/road{
+	icon_state = "horizontaltopborderbottom1"
 	},
-/area/f13/caves)
+/area/f13/wasteland/warren)
 "gnU" = (
 /obj/structure/barricade/tentclothedge{
 	pixel_y = -4
@@ -7215,6 +7202,12 @@
 	pixel_x = -3
 	},
 /turf/open/indestructible/ground/outside/savannah,
+/area/f13/wasteland/warren)
+"gKZ" = (
+/obj/structure/barricade/wooden,
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "horizontalbottombordertop0"
+	},
 /area/f13/wasteland/warren)
 "gLA" = (
 /obj/structure/rack,
@@ -7846,8 +7839,8 @@
 /area/f13/wasteland/warren)
 "hsZ" = (
 /obj/effect/decal/waste,
-/turf/open/indestructible/ground/outside/road{
-	icon_state = "horizontaltopborderbottom2"
+/turf/open/floor/plating/f13/outside/road{
+	icon_state = "horizontaltopborderbottom1"
 	},
 /area/f13/wasteland/warren)
 "htr" = (
@@ -8028,7 +8021,8 @@
 "hyZ" = (
 /obj/structure/lamp_post/quadra,
 /turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "horizontaloutermain1"
+	dir = 4;
+	icon_state = "outerbordercorner"
 	},
 /area/f13/wasteland/ncr)
 "hzo" = (
@@ -8164,7 +8158,7 @@
 	pixel_y = -20
 	},
 /turf/open/indestructible/ground/outside/road{
-	icon_state = "verticalinnermain2"
+	icon_state = "verticalinnermain0"
 	},
 /area/f13/wasteland/ncr)
 "hGk" = (
@@ -8369,12 +8363,6 @@
 	icon_state = "darkdirtysolid"
 	},
 /area/f13/ncr)
-"hPH" = (
-/obj/effect/decal/riverbankcorner{
-	dir = 8
-	},
-/turf/open/indestructible/ground/outside/water,
-/area/f13/wasteland/warren)
 "hPK" = (
 /obj/structure/barricade/sandbags,
 /turf/open/indestructible/ground/outside/road{
@@ -8406,12 +8394,6 @@
 	icon_state = "asteroidfloor"
 	},
 /area/f13/city)
-"hRu" = (
-/obj/item/mine/shrapnel{
-	alpha = 65
-	},
-/turf/open/indestructible/ground/outside/sidewalk,
-/area/f13/wasteland/warren)
 "hRN" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/dresser,
@@ -8615,12 +8597,6 @@
 	},
 /turf/open/floor/wood/wood_common,
 /area/f13/city)
-"ieG" = (
-/obj/effect/decal/riverbank{
-	dir = 1
-	},
-/turf/open/indestructible/ground/outside/water,
-/area/f13/wasteland/warren)
 "igi" = (
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "horizontaltopborderbottom2left"
@@ -8836,6 +8812,14 @@
 	icon_state = "horizontalbottombordertop0"
 	},
 /area/f13/wasteland/ncr)
+"inJ" = (
+/obj/effect/decal/marking{
+	icon_state = "dottedverticalcorroded"
+	},
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "horizontalinnermain2"
+	},
+/area/f13/wasteland/warren)
 "inK" = (
 /obj/structure/closet,
 /obj/effect/spawner/lootdrop/f13/medical/wasteland/meds/drug,
@@ -9623,14 +9607,6 @@
 	icon_state = "bluedirtychess2"
 	},
 /area/f13/ncr)
-"iZs" = (
-/obj/item/mine/shrapnel{
-	alpha = 65
-	},
-/turf/open/indestructible/ground/outside/road{
-	icon_state = "verticalrightborderleft2bottom"
-	},
-/area/f13/wasteland/warren)
 "iZK" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/curtain{
@@ -10328,12 +10304,6 @@
 	icon_state = "verticalrightborderright0"
 	},
 /area/f13/wasteland/warren)
-"jOG" = (
-/obj/effect/decal/riverbank{
-	dir = 6
-	},
-/turf/open/indestructible/ground/outside/water,
-/area/f13/wasteland/warren)
 "jOK" = (
 /turf/closed/wall/f13/store,
 /area/f13/city)
@@ -10627,9 +10597,14 @@
 	},
 /area/f13/city)
 "kaz" = (
-/obj/item/storage/trash_stack,
+/obj/structure/railing/wood{
+	dir = 4;
+	pixel_x = 3
+	},
+/obj/structure/table/wood/settler,
+/obj/item/binoculars,
 /turf/open/indestructible/ground/outside/road{
-	icon_state = "horizontalinnermain1"
+	icon_state = "verticalrightborderleft0"
 	},
 /area/f13/wasteland/warren)
 "kbf" = (
@@ -10766,7 +10741,7 @@
 	},
 /obj/effect/decal/cleanable/blood/old,
 /turf/open/indestructible/ground/outside/road{
-	icon_state = "horizontalinnermain0"
+	icon_state = "horizontalinnermain1"
 	},
 /area/f13/wasteland/warren)
 "kkm" = (
@@ -10817,14 +10792,11 @@
 	},
 /area/f13/wasteland/warren)
 "knO" = (
-/obj/structure/railing/wood{
-	dir = 8;
-	pixel_x = -3
+/obj/effect/decal/marking{
+	icon_state = "dottedverticalcorroded"
 	},
-/obj/structure/table/wood/settler,
-/obj/item/binoculars,
 /turf/open/indestructible/ground/outside/road{
-	icon_state = "verticalleftborderright0"
+	icon_state = "horizontaltopborderbottom2right"
 	},
 /area/f13/wasteland/warren)
 "knT" = (
@@ -11544,9 +11516,10 @@
 /area/f13/city)
 "kZw" = (
 /turf/open/indestructible/ground/outside/road{
-	icon_state = "verticalinnermain2"
+	dir = 8;
+	icon_state = "horizontaltopborderbottom2right"
 	},
-/area/f13/wasteland/ncr)
+/area/f13/wasteland/warren)
 "kZS" = (
 /obj/machinery/light/small/broken{
 	dir = 1
@@ -12050,6 +12023,13 @@
 	icon_state = "outerbordercorner"
 	},
 /area/f13/wasteland/warren)
+"lwB" = (
+/obj/structure/lamp_post/quadra,
+/turf/open/indestructible/ground/outside/sidewalk{
+	dir = 1;
+	icon_state = "outerbordercorner"
+	},
+/area/f13/wasteland/ncr)
 "lxQ" = (
 /obj/effect/spawner/lootdrop/f13/junkspawners,
 /turf/open/indestructible/ground/outside/savannah/edgesnew{
@@ -12893,12 +12873,6 @@
 	},
 /turf/open/indestructible/ground/outside/gravel,
 /area/f13/city)
-"mmB" = (
-/obj/effect/decal/riverbank{
-	dir = 8
-	},
-/turf/open/indestructible/ground/outside/water,
-/area/f13/wasteland/warren)
 "mna" = (
 /obj/structure/closet/crate/large,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/hobo,
@@ -13221,10 +13195,12 @@
 	},
 /area/f13/raiders)
 "mFt" = (
-/obj/effect/decal/riverbank{
+/obj/structure/obstacle/barbedwire/end{
 	dir = 4
 	},
-/turf/open/indestructible/ground/outside/water,
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "verticalinnermain1"
+	},
 /area/f13/wasteland/warren)
 "mFE" = (
 /turf/open/indestructible/ground/outside/road{
@@ -13335,12 +13311,6 @@
 /obj/item/chair,
 /turf/open/floor/wood/wood_common,
 /area/f13/city)
-"mIZ" = (
-/obj/effect/decal/riverbank{
-	dir = 9
-	},
-/turf/open/indestructible/ground/outside/water,
-/area/f13/wasteland/warren)
 "mJo" = (
 /obj/structure/closet/crate/trashcart,
 /obj/item/reagent_containers/pill/patch/healpoultice,
@@ -14425,11 +14395,13 @@
 	},
 /area/f13/wasteland/warren)
 "nID" = (
-/obj/item/mine/shrapnel{
-	alpha = 65
+/obj/effect/decal/marking{
+	icon_state = "dottedverticalcorroded"
 	},
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland/ncr)
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "horizontalinnermain2right"
+	},
+/area/f13/wasteland/warren)
 "nJo" = (
 /obj/structure/flora/grass/jungle,
 /obj/machinery/light/small/broken{
@@ -14440,7 +14412,7 @@
 "nJz" = (
 /obj/structure/car/rubbish1,
 /turf/open/indestructible/ground/outside/road{
-	icon_state = "horizontaltopborderbottom0"
+	icon_state = "topshadowleft"
 	},
 /area/f13/wasteland/warren)
 "nJZ" = (
@@ -14521,8 +14493,8 @@
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/raiders)
 "nOA" = (
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "horizontaloutermainleft"
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "horizontaltopborderbottomleft"
 	},
 /area/f13/wasteland/warren)
 "nPB" = (
@@ -14891,15 +14863,13 @@
 /obj/effect/decal/cleanable/glass,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland/warren)
-"ogI" = (
-/obj/effect/decal/riverbank,
-/turf/open/indestructible/ground/outside/water,
-/area/f13/wasteland/warren)
 "ogP" = (
 /obj/structure/chair/wood{
 	dir = 8
 	},
-/turf/open/indestructible/ground/outside/sidewalk,
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "horizontaloutermain0"
+	},
 /area/f13/wasteland/ncr)
 "ohF" = (
 /obj/structure/table/wood,
@@ -15188,14 +15158,6 @@
 	},
 /turf/open/indestructible/ground/outside/sidewalk,
 /area/f13/wasteland/ncr)
-"owL" = (
-/obj/item/mine/shrapnel{
-	alpha = 65
-	},
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "horizontalbottomborderbottom0"
-	},
-/area/f13/wasteland/warren)
 "oxc" = (
 /obj/structure/chair/sofa{
 	dir = 1
@@ -15230,9 +15192,8 @@
 /turf/closed/wall/f13/store,
 /area/f13/city)
 "oxW" = (
-/obj/structure/barricade/sandbags,
-/turf/open/indestructible/ground/outside/ruins{
-	icon_state = "rubbleplate"
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "verticalleftborderright1"
 	},
 /area/f13/wasteland/warren)
 "oyd" = (
@@ -15492,9 +15453,11 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/city)
 "oOY" = (
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "outermaincornerouter"
+/obj/structure/flora/grass/wasteland{
+	pixel_x = 9;
+	pixel_y = 14
 	},
+/turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland/warren)
 "oPl" = (
 /obj/structure/debris/v4{
@@ -16210,10 +16173,6 @@
 	dir = 10
 	},
 /area/f13/wasteland/warren)
-"pCI" = (
-/obj/effect/decal/riverbankcorner,
-/turf/open/indestructible/ground/outside/water,
-/area/f13/wasteland/warren)
 "pCQ" = (
 /obj/structure/table/reinforced{
 	color = "#c1b6a5"
@@ -16245,6 +16204,11 @@
 	dir = 1
 	},
 /area/f13/wasteland/warren)
+"pEQ" = (
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "verticalleftborderright1"
+	},
+/area/f13/caves)
 "pFw" = (
 /obj/effect/overlay/turfs/cliff{
 	pixel_y = -15
@@ -16906,7 +16870,7 @@
 	dir = 4
 	},
 /turf/open/indestructible/ground/outside/road{
-	icon_state = "horizontaltopborderbottom0"
+	icon_state = "horizontaltopborderbottom2"
 	},
 /area/f13/wasteland/warren)
 "qhp" = (
@@ -17948,7 +17912,7 @@
 "raT" = (
 /obj/effect/decal/remains/deadeyebot,
 /turf/open/indestructible/ground/outside/road{
-	icon_state = "horizontalinnermain0"
+	icon_state = "horizontalinnermain1"
 	},
 /area/f13/wasteland/warren)
 "rbo" = (
@@ -19643,7 +19607,7 @@
 "sDs" = (
 /mob/living/simple_animal/hostile/wolf/playable,
 /turf/open/indestructible/ground/outside/road{
-	icon_state = "horizontalinnermain0"
+	icon_state = "verticalleftborderright0"
 	},
 /area/f13/wasteland/warren)
 "sDQ" = (
@@ -19764,7 +19728,7 @@
 "sJr" = (
 /obj/structure/car,
 /turf/open/indestructible/ground/outside/road{
-	icon_state = "verticalleftborderright0"
+	icon_state = "topshadowleft"
 	},
 /area/f13/wasteland/warren)
 "sKf" = (
@@ -19927,8 +19891,8 @@
 /obj/effect/decal/cleanable/blood/old{
 	icon_state = "gibmid1"
 	},
-/turf/open/indestructible/ground/outside/road{
-	icon_state = "horizontaltopborderbottom0"
+/turf/open/floor/plating/f13/outside/road{
+	icon_state = "horizontaltopborderbottom1"
 	},
 /area/f13/wasteland/warren)
 "sSb" = (
@@ -19939,6 +19903,12 @@
 	icon_state = "verticaloutermain1"
 	},
 /area/f13/city)
+"sSf" = (
+/obj/effect/decal/marking,
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "horizontaltopborderbottom2"
+	},
+/area/f13/wasteland/warren)
 "sSr" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/table,
@@ -20087,7 +20057,7 @@
 /area/f13/wasteland/ncr)
 "sXb" = (
 /obj/effect/overlay/turfs/sidewalk{
-	pixel_x = 16
+	icon_state = "sidewalk_corner"
 	},
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland/ncr)
@@ -20140,12 +20110,6 @@
 	icon_state = "horizontalinnermain2"
 	},
 /area/f13/wasteland/ncr)
-"taX" = (
-/obj/structure/car/rubbish3,
-/turf/open/indestructible/ground/outside/road{
-	icon_state = "verticalinnermain0"
-	},
-/area/f13/wasteland/warren)
 "tbl" = (
 /obj/structure/barricade/sandbags,
 /obj/structure/barricade/wooden,
@@ -20489,6 +20453,7 @@
 /obj/effect/decal/riverbankcorner{
 	dir = 1
 	},
+/obj/effect/decal/fakelattice,
 /turf/open/indestructible/ground/outside/water,
 /area/f13/wasteland/warren)
 "tyk" = (
@@ -20720,7 +20685,7 @@
 	pixel_y = 31
 	},
 /turf/open/indestructible/ground/outside/road{
-	icon_state = "horizontalinnermain0"
+	icon_state = "horizontalinnermain1"
 	},
 /area/f13/wasteland/warren)
 "tIx" = (
@@ -20735,10 +20700,6 @@
 /obj/structure/barricade/wooden,
 /turf/closed/wall/r_wall,
 /area/f13/ncr)
-"tJu" = (
-/obj/structure/barricade/sandbags,
-/turf/open/indestructible/ground/outside/ruins,
-/area/f13/wasteland/warren)
 "tJF" = (
 /obj/structure/wreck/trash/machinepiletwo,
 /turf/open/floor/wood/wood_common,
@@ -20918,6 +20879,14 @@
 /obj/structure/barricade/wooden,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/city)
+"tQy" = (
+/obj/effect/decal/marking{
+	icon_state = "dottedverticalcorroded"
+	},
+/turf/open/floor/plating/f13/outside/road{
+	icon_state = "horizontaltopborderbottom1"
+	},
+/area/f13/wasteland/warren)
 "tQJ" = (
 /obj/structure/chair/stool{
 	dir = 1;
@@ -21021,6 +20990,12 @@
 /obj/item/storage/pill_bottle/chem_tin/foodpaste,
 /turf/open/indestructible/ground/outside/sidewalk,
 /area/f13/ncr)
+"tUF" = (
+/obj/structure/decoration/hatch,
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "horizontalbottombordertop1"
+	},
+/area/f13/wasteland/warren)
 "tUK" = (
 /obj/effect/decal/remains/human,
 /obj/effect/decal/cleanable/blood,
@@ -21280,13 +21255,17 @@
 	pixel_y = -4
 	},
 /turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "verticalleftborderleft0"
+	dir = 8;
+	icon_state = "outerbordercorner"
 	},
 /area/f13/wasteland/warren)
 "ugw" = (
-/obj/structure/car/rubbish1,
+/obj/effect/decal/marking{
+	icon_state = "dottedverticalcorroded"
+	},
 /turf/open/indestructible/ground/outside/road{
-	icon_state = "horizontalinnermain0"
+	dir = 8;
+	icon_state = "horizontalinnermain2left"
 	},
 /area/f13/wasteland/warren)
 "ugG" = (
@@ -21378,11 +21357,11 @@
 	},
 /area/f13/city)
 "uka" = (
-/obj/effect/overlay/turfs/sidewalk{
-	dir = 4
+/obj/structure/barricade/sandbags,
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "horizontalbottombordertop1"
 	},
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland/ncr)
+/area/f13/wasteland/warren)
 "ukr" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/door/airlock/security/glass{
@@ -21663,12 +21642,8 @@
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland/warren)
 "uxg" = (
-/obj/item/flag/locust{
-	desc = "A flag, marking the area as raider territory.";
-	name = "outlaw flag"
-	},
 /turf/open/indestructible/ground/outside/road{
-	icon_state = "verticalinnermain0"
+	icon_state = "verticalinnermaintop"
 	},
 /area/f13/wasteland/warren)
 "uxv" = (
@@ -21956,6 +21931,12 @@
 /obj/structure/flora/ausbushes/fullgrass,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/caves)
+"uKx" = (
+/obj/structure/barricade/sandbags,
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "innershade"
+	},
+/area/f13/wasteland/warren)
 "uKz" = (
 /obj/structure/bed/old,
 /obj/effect/spawner/lootdrop/bedsheet,
@@ -22086,6 +22067,12 @@
 /obj/structure/barricade/sandbags,
 /turf/open/indestructible/ground/outside/savannah/cornersnew{
 	dir = 4
+	},
+/area/f13/wasteland/warren)
+"uQE" = (
+/obj/structure/obstacle/barbedwire,
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "horizontalinnermain1"
 	},
 /area/f13/wasteland/warren)
 "uQT" = (
@@ -22283,8 +22270,15 @@
 /obj/structure/obstacle/barbedwire/end{
 	dir = 8
 	},
+/obj/structure/car/rubbish2{
+	layer = 2.8
+	},
+/turf/open/indestructible/ground/outside/ruins,
+/area/f13/wasteland/warren)
+"vaA" = (
+/obj/structure/barricade/sandbags,
 /turf/open/indestructible/ground/outside/road{
-	icon_state = "verticalinnermain0"
+	icon_state = "horizontalbottombordertop2"
 	},
 /area/f13/wasteland/warren)
 "vaG" = (
@@ -22344,14 +22338,6 @@
 	icon_state = "asteroidfloor"
 	},
 /area/f13/city)
-"vcS" = (
-/obj/item/mine/shrapnel{
-	alpha = 65
-	},
-/turf/open/indestructible/ground/outside/road{
-	icon_state = "verticalrightborderleft0"
-	},
-/area/f13/wasteland/warren)
 "vcT" = (
 /obj/structure/window/fulltile/house,
 /obj/structure/barricade/bars,
@@ -22360,14 +22346,10 @@
 /turf/open/floor/f13/wood,
 /area/f13/raiders)
 "vdd" = (
-/obj/effect/overlay/turfs/cliff{
-	dir = 1;
-	pixel_y = 7
+/obj/structure/car/rubbish2,
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "verticalleftborderright0"
 	},
-/obj/item/mine/shrapnel{
-	alpha = 65
-	},
-/turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland/warren)
 "vdo" = (
 /obj/structure/railing/corner{
@@ -22718,8 +22700,10 @@
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland/warren)
 "vsD" = (
-/turf/open/indestructible/ground/outside/road,
-/area/f13/wasteland/ncr)
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "horizontalbottombordertop1"
+	},
+/area/f13/wasteland/warren)
 "vsK" = (
 /obj/effect/spawner/lootdrop/f13/junkspawners,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -23183,14 +23167,6 @@
 	dir = 10
 	},
 /area/f13/wasteland/ncr)
-"vLR" = (
-/obj/item/mine/shrapnel{
-	alpha = 65
-	},
-/turf/open/indestructible/ground/outside/road{
-	icon_state = "verticalrightborderleft2top"
-	},
-/area/f13/wasteland/warren)
 "vLS" = (
 /obj/item/kirbyplants,
 /turf/open/floor/plasteel/f13/vault_floor/dark{
@@ -23199,7 +23175,7 @@
 /area/f13/ncr)
 "vMc" = (
 /turf/open/indestructible/ground/outside/road{
-	icon_state = "horizontalinnermain0"
+	icon_state = "innershade"
 	},
 /area/f13/caves)
 "vMd" = (
@@ -23613,6 +23589,12 @@
 	icon_state = "whitebluerustychess"
 	},
 /area/f13/city)
+"wgD" = (
+/obj/structure/barricade/sandbags,
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "verticalinnermain2"
+	},
+/area/f13/wasteland/warren)
 "wgK" = (
 /obj/structure/filingcabinet{
 	pixel_x = -10
@@ -23737,14 +23719,6 @@
 	icon_state = "asteroidfloor"
 	},
 /area/f13/city)
-"wlA" = (
-/obj/item/mine/shrapnel{
-	alpha = 65
-	},
-/turf/open/indestructible/ground/outside/road{
-	icon_state = "verticalleftborderright0"
-	},
-/area/f13/wasteland/warren)
 "wmr" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/chair/f13foldupchair{
@@ -23752,6 +23726,16 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
 /area/f13/ncr)
+"wmB" = (
+/obj/structure/railing/wood{
+	dir = 4;
+	pixel_x = 3
+	},
+/obj/structure/barricade/sandbags,
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "verticalrightborderleft0"
+	},
+/area/f13/wasteland/warren)
 "wmP" = (
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "verticalrightborderright0"
@@ -23893,6 +23877,12 @@
 	},
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland/warren)
+"wsY" = (
+/obj/structure/barricade/sandbags,
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "horizontaltopborderbottom2right"
+	},
+/area/f13/wasteland/warren)
 "wtK" = (
 /obj/machinery/light/small/broken{
 	dir = 8
@@ -24031,11 +24021,8 @@
 	},
 /area/f13/wasteland/warren)
 "wAF" = (
-/obj/item/mine/shrapnel{
-	alpha = 65
-	},
 /turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "horizontaltopbordertop0"
+	icon_state = "horizontaltopbordertopright"
 	},
 /area/f13/wasteland/warren)
 "wAO" = (
@@ -24434,7 +24421,7 @@
 "wTV" = (
 /obj/structure/tires,
 /turf/open/indestructible/ground/outside/road{
-	icon_state = "horizontalinnermain0"
+	icon_state = "horizontalbottombordertop0"
 	},
 /area/f13/wasteland/ncr)
 "wUb" = (
@@ -24477,14 +24464,6 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plasteel/f13/vault_floor/red/redchess/redchess2,
 /area/f13/city)
-"wWs" = (
-/obj/item/mine/shrapnel{
-	alpha = 65
-	},
-/turf/open/indestructible/ground/outside/road{
-	icon_state = "horizontaltopborderbottom0"
-	},
-/area/f13/wasteland/warren)
 "wWL" = (
 /obj/effect/decal/waste{
 	icon_state = "goo5"
@@ -24587,14 +24566,6 @@
 "xbR" = (
 /turf/closed/wall/f13/wood/house,
 /area/f13/city)
-"xcb" = (
-/obj/item/mine/shrapnel{
-	alpha = 65
-	},
-/turf/open/indestructible/ground/outside/road{
-	icon_state = "horizontalinnermain1"
-	},
-/area/f13/wasteland/warren)
 "xcy" = (
 /obj/structure/flora/tree/tall{
 	icon_state = "tree_2"
@@ -24962,13 +24933,11 @@
 /turf/open/floor/plating/tunnel,
 /area/f13/caves)
 "xpw" = (
-/obj/effect/decal/marking{
-	icon_state = "doublehorizontal"
+/turf/open/indestructible/ground/outside/sidewalk{
+	dir = 4;
+	icon_state = "outerbordercorner"
 	},
-/turf/open/indestructible/ground/outside/road{
-	icon_state = "horizontalinnermain2left"
-	},
-/area/f13/wasteland/warren)
+/area/f13/wasteland/ncr)
 "xpx" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -25044,8 +25013,9 @@
 	},
 /area/f13/caves)
 "xth" = (
-/obj/structure/car/rubbish2,
-/turf/open/indestructible/ground/outside/ruins,
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "verticalinnermainbottom"
+	},
 /area/f13/wasteland/warren)
 "xtt" = (
 /obj/structure/spider/stickyweb,
@@ -25750,12 +25720,9 @@
 /turf/open/floor/wood/wood_wide,
 /area/f13/city)
 "yah" = (
-/obj/effect/decal/marking{
-	icon_state = "doublehorizontal"
-	},
+/obj/effect/decal/marking,
 /turf/open/indestructible/ground/outside/road{
-	dir = 8;
-	icon_state = "horizontalinnermain2left"
+	icon_state = "horizontalinnermain1"
 	},
 /area/f13/wasteland/warren)
 "yaI" = (
@@ -25796,14 +25763,6 @@
 /obj/structure/spider/stickyweb,
 /turf/open/floor/plasteel/dark,
 /area/f13/caves)
-"ycP" = (
-/obj/item/mine/shrapnel{
-	alpha = 65
-	},
-/turf/open/indestructible/ground/outside/road{
-	icon_state = "verticalinnermain0"
-	},
-/area/f13/wasteland/warren)
 "ycV" = (
 /obj/structure/window/fulltile/house{
 	dir = 2;
@@ -25854,6 +25813,12 @@
 	},
 /turf/open/indestructible/ground/outside/water,
 /area/f13/city)
+"yff" = (
+/obj/structure/barricade/sandbags,
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "verticalleftborderright1"
+	},
+/area/f13/wasteland/warren)
 "yfy" = (
 /obj/effect/turf_decal/loading_area,
 /turf/open/floor/plasteel/f13/vault_floor/dark,
@@ -26889,25 +26854,25 @@ jLg
 rlz
 dso
 oWz
-oWz
+pEQ
+oxW
+oxW
+oxW
+pDT
+pDT
+oxW
+oxW
+fWJ
+fWJ
+fWJ
+oxW
+oxW
+oxW
 pDT
 pDT
 pDT
 pDT
-pDT
-pDT
-pDT
-pDT
-pDT
-pDT
-pDT
-pDT
-pDT
-pDT
-pDT
-pDT
-pbp
-pbp
+jfK
 wXB
 lig
 cQt
@@ -27148,23 +27113,23 @@ gmr
 qdy
 qdy
 snq
-snq
-snq
-snq
-snq
-snq
-snq
-snq
-snq
-snq
-snq
+duo
+duo
+duo
+duo
+duo
+duo
+duo
+qpZ
+duo
+duo
 snq
 snq
 snq
 snq
 snq
 pbp
-pbp
+jfK
 wXB
 uUe
 bPl
@@ -27421,7 +27386,7 @@ jWt
 jWt
 ltk
 nFf
-pbp
+vsD
 wXB
 uUe
 uUe
@@ -27678,7 +27643,7 @@ xOe
 xOe
 uch
 nFf
-pbp
+vsD
 wXB
 uUe
 sQw
@@ -27934,8 +27899,8 @@ mhA
 iMH
 xOe
 yfP
-nFf
-pbp
+qhK
+vsD
 wXB
 uUe
 wUb
@@ -28191,8 +28156,8 @@ jWX
 iij
 pjM
 plO
-nFf
-pbp
+qhK
+vsD
 wXB
 uUe
 uUe
@@ -28448,8 +28413,8 @@ rvf
 rvf
 xOe
 vdo
-nFf
-pbp
+qhK
+vsD
 wXB
 uUe
 iJK
@@ -28705,8 +28670,8 @@ xOe
 lia
 xOe
 uvL
-nFf
-pbp
+qhK
+vsD
 wXB
 uUe
 itq
@@ -28963,7 +28928,7 @@ qEM
 xOe
 uch
 nFf
-pbp
+vsD
 wXB
 uUe
 rFz
@@ -29220,7 +29185,7 @@ kYT
 xOe
 uch
 nFf
-pbp
+jfK
 wXB
 uUe
 uUe
@@ -29477,7 +29442,7 @@ qil
 xOe
 uch
 nFf
-pbp
+jfK
 wXB
 lsq
 ged
@@ -29487,7 +29452,7 @@ lsq
 lsq
 lsq
 lsq
-lsq
+yeV
 boQ
 boQ
 lsq
@@ -29733,8 +29698,8 @@ xOe
 xOe
 xOe
 uch
-nFf
-pbp
+igi
+vsD
 wXB
 nns
 tyk
@@ -29834,7 +29799,7 @@ jfK
 tEC
 tfL
 ceg
-eUM
+ceg
 kEs
 oIa
 xHj
@@ -29991,7 +29956,7 @@ gsz
 deK
 kEF
 vfB
-lMO
+vsD
 wXB
 wSU
 wSU
@@ -30248,7 +30213,7 @@ huf
 bQh
 qLx
 vfB
-lMO
+vsD
 wXB
 wSU
 gxm
@@ -30355,7 +30320,7 @@ kmn
 kzz
 vEp
 ceg
-eUM
+ceg
 ceg
 iha
 wXB
@@ -30505,7 +30470,7 @@ yiM
 njW
 mrs
 lHY
-lMO
+vsD
 wXB
 wSU
 pjr
@@ -30762,7 +30727,7 @@ vDK
 gjQ
 fTO
 igi
-pbp
+vsD
 wXB
 wSU
 pDX
@@ -31019,7 +30984,7 @@ gsz
 xOe
 dHQ
 vfB
-pbp
+vsD
 wXB
 wSU
 xzN
@@ -31276,7 +31241,7 @@ huf
 xOe
 ayz
 lHY
-pbp
+vsD
 wXB
 wSU
 uRI
@@ -31369,8 +31334,8 @@ uch
 qhK
 pbp
 iqb
-rsF
-pbp
+jWr
+lMO
 lMO
 jfK
 wXB
@@ -31533,7 +31498,7 @@ rFO
 xOe
 uch
 nFf
-pbp
+vsD
 wXB
 wSU
 xzN
@@ -31557,11 +31522,11 @@ qlr
 lkA
 cAF
 wSU
-lsq
+yeV
 uux
 boQ
 boQ
-lsq
+pHs
 nvY
 ceg
 ceg
@@ -31626,9 +31591,9 @@ ipp
 qhK
 pbp
 uHQ
-rsF
-pbp
-pbp
+jWr
+lMO
+lMO
 jfK
 wXB
 oTw
@@ -31790,7 +31755,7 @@ xOe
 xOe
 uch
 nFf
-pbp
+vsD
 wXB
 wSU
 jJS
@@ -31817,7 +31782,7 @@ wSU
 uch
 nFf
 pbp
-pDT
+jfK
 wXB
 nvY
 ceg
@@ -31860,7 +31825,7 @@ rKB
 xbR
 uch
 qhK
-pbp
+lMO
 jfK
 wXB
 eOz
@@ -31883,9 +31848,9 @@ fTO
 qhK
 pbp
 umW
-rsF
-pbp
-pbp
+jWr
+lMO
+lMO
 jfK
 wXB
 tfL
@@ -32047,7 +32012,7 @@ tOT
 qjU
 uch
 nFf
-lMO
+jfK
 wXB
 wSU
 wMC
@@ -32072,7 +32037,7 @@ qeU
 tRU
 wSU
 uch
-nFf
+pkQ
 pbp
 jfK
 wXB
@@ -32117,7 +32082,7 @@ cBd
 xbR
 uch
 qhK
-pbp
+lMO
 jfK
 wXB
 dnk
@@ -32140,8 +32105,8 @@ ddT
 qhK
 pbp
 lMO
-rsF
-pbp
+jWr
+lMO
 pbp
 jfK
 wXB
@@ -32153,7 +32118,7 @@ kmn
 fTN
 ceg
 ceg
-eUM
+ceg
 ceg
 xQS
 iha
@@ -32304,7 +32269,7 @@ dgH
 dgH
 uch
 nFf
-lMO
+jfK
 wXB
 wSU
 vix
@@ -32329,7 +32294,7 @@ hwv
 wSU
 wSU
 uch
-nFf
+vfB
 pbp
 jfK
 wXB
@@ -32374,7 +32339,7 @@ cBd
 eOz
 uch
 kQH
-pbp
+lMO
 jfK
 wXB
 kYw
@@ -32397,14 +32362,14 @@ uch
 nFf
 pbp
 pbp
-rsF
-pbp
+jWr
+lMO
 pbp
 jfK
 wXB
 tfL
 ceg
-eUM
+ceg
 gFf
 cVr
 nHP
@@ -32561,7 +32526,7 @@ dgH
 dgH
 uch
 nFf
-lMO
+jfK
 wXB
 wSU
 wSU
@@ -32573,7 +32538,7 @@ gPG
 wSU
 uch
 nFf
-lMO
+vsD
 wXB
 wSU
 kWP
@@ -32586,9 +32551,9 @@ ybA
 oHU
 wSU
 uch
-nFf
-pbp
-jfK
+vfB
+lMO
+vsD
 wXB
 nvY
 ceg
@@ -32631,7 +32596,7 @@ iEf
 aSz
 uch
 kQH
-pbp
+lMO
 vMJ
 wXB
 mzI
@@ -32655,7 +32620,7 @@ nFf
 pbp
 lMO
 rsF
-pbp
+lMO
 pbp
 jfK
 wXB
@@ -32818,7 +32783,7 @@ dgH
 xnW
 uch
 nFf
-uHQ
+jfK
 dKP
 boQ
 boQ
@@ -32830,7 +32795,7 @@ jeT
 iWJ
 vDD
 nFf
-lMO
+vsD
 wXB
 wSU
 oHU
@@ -32844,8 +32809,8 @@ dSY
 pWM
 uch
 qgt
-pbp
-jfK
+lMO
+vsD
 wXB
 nvY
 ceg
@@ -32888,7 +32853,7 @@ cBd
 cBi
 uch
 nFf
-pbp
+lMO
 dwu
 wXB
 xWL
@@ -33087,7 +33052,7 @@ pDT
 qlM
 pDT
 pbp
-lMO
+vsD
 wXB
 wSU
 ktI
@@ -33100,9 +33065,9 @@ uJr
 oHU
 xkY
 vvp
-nFf
-pbp
-jfK
+vfB
+lMO
+dwu
 wXB
 ekO
 ceg
@@ -33144,8 +33109,8 @@ lJZ
 cBd
 xbR
 uch
-nFf
-pbp
+qhK
+lMO
 tHr
 wXB
 xbR
@@ -33166,10 +33131,10 @@ xbR
 xbR
 uch
 nFf
-pbp
+lMO
 lMO
 jWr
-pbp
+lMO
 pbp
 jfK
 tEC
@@ -33344,7 +33309,7 @@ snq
 cuH
 snq
 pbp
-jfK
+vsD
 wXB
 wSU
 oHU
@@ -33357,9 +33322,9 @@ wvA
 bPm
 wSU
 uch
-kQH
-vrA
-ykS
+wsY
+mwd
+vaA
 wXB
 ekO
 vUK
@@ -33401,8 +33366,8 @@ fFF
 iVn
 aNm
 uch
-nFf
-pbp
+qhK
+lMO
 xJk
 wXB
 bKX
@@ -33423,10 +33388,10 @@ cBd
 xbR
 uch
 nFf
-pbp
 lMO
-rsF
-pbp
+uHQ
+kRp
+lMO
 pbp
 jfK
 xuU
@@ -33589,7 +33554,7 @@ uUe
 sfe
 uch
 nFf
-lMO
+jfK
 ouI
 jWt
 jWt
@@ -33601,7 +33566,7 @@ jWt
 qAQ
 ltk
 nFf
-jfK
+vsD
 wXB
 wSU
 oHU
@@ -33615,8 +33580,8 @@ wSU
 wSU
 fvl
 pkQ
-pbp
-ykS
+lMO
+vaA
 wXB
 ekO
 qkJ
@@ -33658,8 +33623,8 @@ cBd
 sEh
 cBi
 uch
-nFf
-pbp
+qhK
+lMO
 jfK
 wXB
 xbR
@@ -33680,10 +33645,10 @@ leW
 dtK
 uch
 nFf
-pbp
-pbp
-jWr
-pbp
+lMO
+uHQ
+kRp
+lMO
 pbp
 jfK
 ecA
@@ -33846,7 +33811,7 @@ uUe
 pSg
 uch
 nFf
-lMO
+jfK
 wXB
 aTg
 aTg
@@ -33857,8 +33822,8 @@ mlR
 aTg
 aTg
 uch
-nFf
-jfK
+pkQ
+dwu
 wXB
 wSU
 wvA
@@ -33872,8 +33837,8 @@ itj
 bcH
 uch
 vfB
-pbp
-jfK
+lMO
+dwu
 wXB
 ekO
 gFf
@@ -33915,8 +33880,8 @@ pys
 sEh
 laH
 uch
-nFf
-pbp
+qhK
+lMO
 jfK
 wXB
 xgT
@@ -33937,11 +33902,11 @@ rAa
 iIM
 uch
 qhK
-pbp
-pbp
+lMO
+lMO
 kRp
-pbp
-pbp
+lMO
+lMO
 jfK
 wXB
 tfL
@@ -34103,7 +34068,7 @@ uUe
 dgH
 uch
 nFf
-tHr
+jfK
 wXB
 aTg
 lSm
@@ -34114,8 +34079,8 @@ eTy
 iim
 aTg
 ijC
-nFf
-jfK
+vfB
+dwu
 wXB
 pWM
 wvA
@@ -34129,8 +34094,8 @@ mUJ
 slF
 uch
 lHY
-pbp
-jfK
+lMO
+vsD
 wXB
 nvY
 mtU
@@ -34194,11 +34159,11 @@ sAr
 cBi
 ipp
 qhK
-pbp
-pbp
-jWr
-pbp
-pbp
+lMO
+lMO
+kRp
+lMO
+lMO
 jfK
 wXB
 tfL
@@ -34215,15 +34180,15 @@ fTN
 iha
 dNs
 uch
-nFf
-pbp
-pbp
-pbp
-pbp
-pbp
-pbp
-pbp
-pbp
+frg
+pDT
+oxW
+oxW
+oxW
+oxW
+oxW
+pDT
+pDT
 gsT
 lsq
 lsq
@@ -34360,7 +34325,7 @@ uUe
 dgH
 ipp
 nFf
-pbp
+jfK
 wXB
 aTg
 juT
@@ -34371,8 +34336,8 @@ dbu
 wFa
 mlR
 uch
-nFf
-jfK
+vfB
+dwu
 wXB
 gqH
 wvA
@@ -34387,7 +34352,7 @@ slF
 uch
 nFf
 pbp
-jfK
+vsD
 wXB
 nvY
 fjy
@@ -34451,15 +34416,15 @@ cBd
 xbR
 ddT
 qhK
-pbp
-pbp
-rsF
-pbp
-pbp
-jfK
+lMO
+lMO
+jWr
+lMO
+lMO
+vsD
 wXB
 tfL
-eUM
+ceg
 lVT
 kmn
 kmn
@@ -34473,14 +34438,14 @@ iha
 dNs
 uch
 bbS
+lMO
+mwd
+mwd
+lMO
+lMO
+lMO
 pbp
-vrA
-vrA
-pbp
-pbp
-pbp
-pbp
-pbp
+jfK
 wXB
 ceg
 ceg
@@ -34617,7 +34582,7 @@ uUe
 wha
 fTO
 nFf
-pbp
+vsD
 wXB
 aTg
 ird
@@ -34628,8 +34593,8 @@ lfh
 cBd
 mEA
 uch
-nFf
-jfK
+lHY
+dwu
 wXB
 wSU
 oPO
@@ -34707,13 +34672,13 @@ cBi
 xbR
 xbR
 uch
-nFf
-pbp
-pbp
-pbp
+qhK
 lMO
-pbp
-jfK
+uHQ
+rIX
+lMO
+lMO
+vsD
 wXB
 tfL
 ceg
@@ -34729,15 +34694,15 @@ ceg
 iha
 wXB
 uch
-nFf
+vfB
+uHQ
+uHQ
+uHQ
+lMO
+lMO
+lMO
 pbp
-pbp
-pbp
-pbp
-pbp
-pbp
-pbp
-pbp
+jfK
 wXB
 ceg
 ceg
@@ -34874,7 +34839,7 @@ uUe
 wha
 fTO
 pkQ
-pbp
+dwu
 wXB
 aTg
 hKR
@@ -34886,7 +34851,7 @@ vfd
 mlR
 uch
 nFf
-jfK
+vsD
 wXB
 wSU
 wSU
@@ -34964,13 +34929,13 @@ boQ
 boQ
 sad
 ulI
-nFf
-pbp
-ubI
-pbp
+qhK
 uHQ
-pbp
-jfK
+ubI
+rIX
+uHQ
+uHQ
+vsD
 wXB
 tfL
 ceg
@@ -34986,15 +34951,15 @@ ceg
 iha
 wXB
 uch
-nFf
-pbp
-pbp
-pbp
+vfB
+uHQ
+uHQ
+lMO
 pbp
 pbp
 pfm
 pbp
-pbp
+jfK
 wXB
 aGJ
 ceg
@@ -35131,7 +35096,7 @@ nYM
 dgH
 fTO
 lHY
-lMO
+vsD
 wXB
 aTg
 tNn
@@ -35143,7 +35108,7 @@ oNz
 aTg
 uch
 nFf
-jfK
+vsD
 wXB
 lsq
 lsq
@@ -35214,20 +35179,20 @@ pDT
 qlM
 fWJ
 mgf
-pDT
-pDT
-pDT
+oxW
+oxW
+oxW
 saU
 fWJ
 mgf
 pbp
-pbp
-pbp
-pbp
-pbp
-lMO
-pbp
-jfK
+uHQ
+uHQ
+uHQ
+uHQ
+uHQ
+uHQ
+vsD
 wXB
 tfL
 ceg
@@ -35238,20 +35203,20 @@ kmn
 cVr
 cVr
 nHP
-eUM
+ceg
 ceg
 iha
 dNs
 uch
-nFf
-pbp
-pbp
-pbp
-pbp
-pbp
-pbp
-pbp
-pbp
+vfB
+lMO
+lMO
+snq
+snq
+snq
+snq
+snq
+snq
 aXI
 ceg
 vSw
@@ -35388,7 +35353,7 @@ rLd
 dgH
 fTO
 nFf
-ubO
+vsD
 wXB
 aTg
 cBd
@@ -35400,7 +35365,7 @@ vXJ
 aTg
 uch
 pkQ
-jfK
+vsD
 wXB
 gpZ
 lsq
@@ -35414,8 +35379,8 @@ lsq
 lsq
 uch
 nFf
-pbp
-pbp
+lMO
+jfK
 wXB
 nvY
 mEQ
@@ -35459,25 +35424,25 @@ bHg
 uch
 nFf
 pbp
-lMO
-pbp
-pbp
-pbp
-lMO
-dwu
-lMO
-pbp
-lMO
+pmU
+pmU
+pmU
+ejl
+ejl
+rHP
+rHP
+ejl
+pmU
 cuH
-dwu
-lMO
-pbp
-pbp
-pbp
-lMO
-dwu
-lMO
-pbp
+ejl
+ejl
+ejl
+ejl
+ejl
+ejl
+ejl
+pmU
+uHQ
 jWv
 mFE
 mFE
@@ -35500,9 +35465,9 @@ ceg
 iha
 dNs
 mKR
-nFf
+kZw
 pbp
-pbp
+jfK
 sqj
 tKj
 tKj
@@ -35645,7 +35610,7 @@ xqf
 sfe
 ddT
 nFf
-pbp
+jfK
 wXB
 aTg
 xYZ
@@ -35657,7 +35622,7 @@ cBd
 tiA
 uch
 vfB
-jfK
+vsD
 wXB
 kWc
 lsq
@@ -35671,8 +35636,8 @@ boQ
 pHs
 ipp
 pkQ
-pbp
-pbp
+lMO
+vsD
 wXB
 nvY
 ceg
@@ -35714,27 +35679,27 @@ jSm
 aXI
 pSg
 uch
-nFf
-pbp
-lMO
-lMO
-pbp
-pbp
-pbp
-lMO
-pbp
-pbp
-pbp
+ubC
+snq
+snq
+duo
+duo
+duo
+duo
+duo
+duo
+snq
+snq
 cuH
-lMO
-dwu
-lMO
-pbp
-pbp
-pbp
-lMO
-pbp
-oED
+snq
+duo
+duo
+snq
+duo
+snq
+snq
+snq
+jWv
 sXC
 anQ
 auw
@@ -35743,7 +35708,7 @@ auw
 gtN
 jzk
 oyd
-eGz
+wAF
 ceg
 ceg
 xQS
@@ -35759,7 +35724,7 @@ soJ
 vIy
 thB
 voO
-voO
+gKZ
 knK
 vsb
 xXu
@@ -35902,7 +35867,7 @@ uUe
 vgj
 uch
 nFf
-vMJ
+jfK
 wXB
 aTg
 vTP
@@ -35919,17 +35884,17 @@ wXB
 kWc
 dLo
 nFf
-pbp
-clC
-pbp
-pbp
-clC
+pDT
+vdd
+pDT
+pDT
+vdd
 pDT
 wXB
 cjz
 vfB
-pbp
-pbp
+uHQ
+vsD
 dKP
 boQ
 boQ
@@ -35991,7 +35956,7 @@ jWt
 jWt
 jWt
 tRl
-tKc
+xEN
 anQ
 tgc
 rjD
@@ -36000,7 +35965,7 @@ fhp
 bnV
 gtN
 oOY
-gYg
+oOY
 anq
 gVA
 gVA
@@ -36016,7 +35981,7 @@ qzI
 uch
 nFf
 pbp
-pbp
+jfK
 gsT
 mzI
 eKG
@@ -36159,7 +36124,7 @@ uUe
 lsq
 uch
 pkQ
-lMO
+vsD
 wXB
 aTg
 aTg
@@ -36185,21 +36150,21 @@ pbp
 wXB
 uch
 lHY
-pbp
 lMO
-pbp
-cuH
-pbp
-pbp
-pbp
-pbp
-pbp
-pbp
-pbp
-pbp
-pbp
-pbp
-pbp
+lMO
+pDT
+pDT
+pDT
+oxW
+oxW
+oxW
+fWJ
+fWJ
+fWJ
+oxW
+pDT
+pDT
+pDT
 sDs
 pDT
 wXB
@@ -36256,9 +36221,9 @@ rme
 ucF
 ewI
 uNY
+dou
+fvJ
 nRY
-gFd
-gFd
 gFd
 gFd
 qHH
@@ -36273,7 +36238,7 @@ iWJ
 vDD
 thB
 voO
-pbp
+jfK
 dKP
 xYh
 qRF
@@ -36416,7 +36381,7 @@ cBv
 sfe
 uch
 vfB
-ubO
+dwu
 wXB
 aTg
 mwX
@@ -36428,7 +36393,7 @@ ehj
 aTg
 fTO
 nFf
-jfK
+vsD
 sli
 hOB
 uch
@@ -36442,21 +36407,21 @@ jfK
 dKP
 qnv
 nFf
-pbp
 lMO
-pbp
+lMO
+xAm
 cuH
-pbp
-pbp
-pbp
-pbp
-pbp
-pbp
-pbp
-pbp
-pbp
-pbp
-pbp
+ejl
+ejl
+ejl
+rHP
+rHP
+rHP
+ejl
+ejl
+ejl
+xAm
+xAm
 pbp
 pbp
 wXB
@@ -36502,8 +36467,8 @@ ryb
 vuD
 uch
 sJr
-jfK
-jfK
+pDT
+pDT
 ibu
 tKc
 miQ
@@ -36513,9 +36478,9 @@ rpz
 ucF
 ucF
 uNY
-eGt
-saU
-fWJ
+fvJ
+cUZ
+xlN
 fWJ
 mgf
 pDT
@@ -36531,9 +36496,9 @@ pbp
 pbp
 voO
 pbp
-pbp
-pbp
-pbp
+pDT
+pDT
+pDT
 ydC
 xvB
 xvB
@@ -36673,7 +36638,7 @@ qkx
 sfe
 uch
 lHY
-lMO
+dwu
 ubM
 aTg
 igV
@@ -36685,7 +36650,7 @@ inf
 aTg
 pxS
 nFf
-lMO
+vsD
 tEC
 wha
 ipp
@@ -36696,23 +36661,23 @@ eVc
 uHQ
 pbp
 lMO
-pbp
+pDT
 pDT
 pbp
-pbp
-pbp
-pbp
-cuH
-pbp
-pbp
-pbp
-pbp
-pbp
-pbp
-pbp
-pbp
-pbp
-pbp
+lMO
+lMO
+snq
+snq
+snq
+duo
+qpZ
+qpZ
+duo
+duo
+duo
+snq
+snq
+snq
 pbp
 pbp
 pbp
@@ -36759,8 +36724,8 @@ uNG
 vuD
 uch
 nFf
-jfK
-jfK
+pbp
+pbp
 ibu
 tKc
 miQ
@@ -36770,8 +36735,8 @@ ucF
 bul
 rjD
 uNY
-eGt
-pmU
+cUZ
+xlN
 iBU
 ejl
 pmU
@@ -36930,7 +36895,7 @@ sfe
 sfe
 uch
 nFf
-lMO
+dwu
 wXB
 aTg
 cBd
@@ -36942,7 +36907,7 @@ inf
 aTg
 ddT
 nFf
-lMO
+vsD
 tEC
 cjT
 fTO
@@ -36970,8 +36935,8 @@ jWt
 jWt
 jWt
 wla
-nFf
-pbp
+qhK
+lMO
 pbp
 wXB
 kEs
@@ -37016,8 +36981,8 @@ muY
 vuD
 uch
 lCk
-jfK
-jfK
+tjK
+lMO
 xzt
 tKc
 miQ
@@ -37027,7 +36992,7 @@ ucF
 fAp
 brC
 uNY
-eGt
+uxg
 snq
 snq
 snq
@@ -37041,13 +37006,13 @@ snq
 snq
 snq
 cuH
+snq
 pbp
 pbp
 pbp
-pbp
-voO
-voO
-pbp
+bKW
+bKW
+snq
 ydC
 xvB
 xvB
@@ -37187,7 +37152,7 @@ sfe
 sfe
 uch
 nFf
-pbp
+dwu
 wXB
 aTg
 xJH
@@ -37199,7 +37164,7 @@ sEh
 uDJ
 uch
 nFf
-jfK
+vsD
 xuU
 fuN
 ddT
@@ -37214,7 +37179,7 @@ oKA
 wla
 nFf
 pbp
-jfK
+vsD
 wXB
 gcd
 gcd
@@ -37227,8 +37192,8 @@ xTc
 xTc
 uUe
 lSK
-nFf
-pbp
+qhK
+lMO
 pbp
 wXB
 lVT
@@ -37273,8 +37238,8 @@ vuD
 vuD
 uch
 nFf
-jfK
-jfK
+lMO
+lMO
 dKP
 tdO
 miQ
@@ -37301,7 +37266,7 @@ qAQ
 wla
 nFf
 pbp
-pbp
+jfK
 oKA
 gVA
 gVA
@@ -37444,7 +37409,7 @@ oxu
 lsq
 uch
 nFf
-pbp
+vsD
 wXB
 aTg
 bsF
@@ -37456,7 +37421,7 @@ sEh
 aTg
 uch
 nFf
-jfK
+vsD
 wXB
 gpZ
 aXE
@@ -37470,8 +37435,8 @@ jWt
 qzI
 uch
 nFf
-pbp
-jfK
+lMO
+vsD
 wXB
 qDY
 twI
@@ -37484,8 +37449,8 @@ his
 wiX
 uUe
 uch
-nFf
-pbp
+pkQ
+lMO
 pbp
 wXB
 lVT
@@ -37529,11 +37494,11 @@ vXJ
 pSR
 rRl
 uch
-nFf
-jfK
-jfK
-jfK
-tKc
+pkQ
+lMO
+lMO
+pDT
+xth
 miQ
 ucF
 cey
@@ -37558,7 +37523,7 @@ ezi
 tfL
 nFf
 pbp
-pbp
+jfK
 gsT
 hos
 ezi
@@ -37701,7 +37666,7 @@ jOK
 sfe
 uch
 nFf
-pbp
+vsD
 wXB
 aTg
 xon
@@ -37726,9 +37691,9 @@ jOK
 jOK
 sgb
 uZK
-nFf
-pbp
-jfK
+qhK
+lMO
+vsD
 wXB
 mRw
 fps
@@ -37741,8 +37706,8 @@ his
 haK
 gOZ
 uch
-nFf
-pbp
+vfB
+lMO
 pbp
 wXB
 lVT
@@ -37786,11 +37751,11 @@ dYJ
 qDO
 xfM
 uch
-lCk
-jfK
-jfK
-jfK
-tKc
+fit
+ugw
+lMO
+pmU
+xth
 miQ
 ucF
 cAq
@@ -37815,7 +37780,7 @@ pSg
 tfL
 nFf
 pbp
-pbp
+jfK
 gsT
 ezi
 pSg
@@ -37958,7 +37923,7 @@ jOK
 lsq
 uch
 nFf
-pbp
+vsD
 wXB
 aTg
 aTg
@@ -37983,8 +37948,8 @@ uBR
 jOK
 sgb
 uch
-nFf
-pbp
+qhK
+lMO
 jfK
 wXB
 xUJ
@@ -37998,8 +37963,8 @@ pyG
 foT
 wMr
 uch
-nFf
-pbp
+vfB
+lMO
 pbp
 wXB
 lVT
@@ -38043,11 +38008,11 @@ dbu
 qDO
 xfM
 uch
-nFf
-jfK
-jfK
-jfK
-tKc
+vfB
+uHQ
+lMO
+snq
+xth
 miQ
 fhp
 ucF
@@ -38070,9 +38035,9 @@ oHU
 afX
 mzI
 tfL
-nFf
-pbp
-pbp
+pkQ
+lMO
+jfK
 gsT
 pSg
 sgb
@@ -38215,7 +38180,7 @@ jOK
 lsq
 uch
 nFf
-pbp
+vsD
 wXB
 scw
 lsq
@@ -38240,8 +38205,8 @@ mcn
 jOK
 mzI
 uch
-nFf
-pbp
+pkQ
+lMO
 jfK
 wXB
 gcd
@@ -38255,8 +38220,8 @@ his
 vcj
 xeI
 uch
-nFf
-pbp
+vfB
+lMO
 pbp
 wXB
 lVT
@@ -38300,9 +38265,9 @@ dbu
 qDO
 xfM
 uch
-nFf
-jfK
-jfK
+vfB
+uHQ
+lMO
 oKA
 xEN
 bTs
@@ -38327,9 +38292,9 @@ mZK
 xoX
 rqV
 tfL
-nFf
-pbp
-pbp
+vfB
+lMO
+jfK
 sli
 sgb
 mzI
@@ -38472,7 +38437,7 @@ jOK
 sfe
 uch
 nFf
-pbp
+vsD
 wXB
 afX
 afX
@@ -38497,8 +38462,8 @@ gxv
 jOK
 mzI
 uch
-nFf
-pbp
+vfB
+lMO
 xJk
 wXB
 lsq
@@ -38512,7 +38477,7 @@ vcj
 hKu
 uUe
 uch
-nFf
+lHY
 pbp
 pbp
 wXB
@@ -38557,9 +38522,9 @@ kNj
 hdW
 tSG
 uch
-lCk
-jfK
-jfK
+knO
+nID
+lMO
 fca
 eGz
 fvJ
@@ -38584,8 +38549,8 @@ gAI
 gui
 jnN
 tfL
-nFf
-pbp
+vfB
+lMO
 iqb
 tEC
 mzI
@@ -38729,7 +38694,7 @@ mUw
 cjT
 uch
 nFf
-pbp
+vsD
 wXB
 afX
 aSh
@@ -38741,7 +38706,7 @@ qGG
 afX
 uch
 nFf
-jfK
+lMO
 wXB
 jOK
 jPg
@@ -38754,8 +38719,8 @@ wCJ
 jOK
 mzI
 uch
-nFf
-pbp
+vfB
+lMO
 jfK
 wXB
 azC
@@ -38815,8 +38780,8 @@ tIC
 vuD
 uch
 nFf
-jfK
-jfK
+pbp
+pbp
 fca
 whQ
 nOA
@@ -38841,9 +38806,9 @@ viz
 afX
 ezi
 tfL
-nFf
-pbp
-pbp
+vfB
+uHQ
+vsD
 xuU
 xWL
 sgb
@@ -38985,8 +38950,8 @@ cBd
 dOV
 wha
 uch
-nFf
-vMJ
+pkQ
+vsD
 wXB
 afX
 iOU
@@ -38998,7 +38963,7 @@ pxX
 afX
 uch
 nFf
-jfK
+lMO
 wXB
 jOK
 wnO
@@ -39011,9 +38976,9 @@ jOK
 jOK
 mzI
 uch
-nFf
-pbp
-jfK
+vfB
+lMO
+vsD
 wXB
 uch
 fda
@@ -39072,17 +39037,17 @@ pIS
 vHi
 uch
 ubC
-jfK
+snq
 snq
 ibu
 uch
-nFf
+vfB
 uHQ
-pbp
-pbp
-pbp
-lMO
-jfK
+uHQ
+uHQ
+uHQ
+uHQ
+uHQ
 sli
 ipp
 iha
@@ -39098,9 +39063,9 @@ rvy
 afX
 ezi
 tfL
-nFf
-pbp
-pbp
+vfB
+uHQ
+vsD
 gsT
 sgb
 xWL
@@ -39242,8 +39207,8 @@ eFL
 jOK
 wha
 uch
-nFf
-lMO
+vfB
+vsD
 wXB
 afX
 edE
@@ -39255,7 +39220,7 @@ jRF
 afX
 uch
 nFf
-jfK
+lMO
 wXB
 jOK
 jOK
@@ -39268,9 +39233,9 @@ tFb
 jOK
 mOz
 mKR
-nFf
-pbp
-jfK
+vfB
+uHQ
+vsD
 wXB
 uch
 ciQ
@@ -39333,13 +39298,13 @@ aYs
 jWt
 nUd
 uch
-nFf
+vfB
 ubO
-pbp
-pbp
-pbp
-pbp
-jfK
+uHQ
+rIX
+uHQ
+uHQ
+uHQ
 xuU
 fTO
 iha
@@ -39355,9 +39320,9 @@ oHU
 tHM
 ezi
 tfL
-nFf
+vfB
 iqb
-pbp
+vsD
 gsT
 xWL
 ezi
@@ -39499,8 +39464,8 @@ rCH
 jOK
 cjT
 uch
-nFf
-lMO
+vfB
+vsD
 sli
 afX
 afX
@@ -39512,7 +39477,7 @@ afX
 afX
 uch
 nFf
-jfK
+lMO
 wXB
 jOK
 ftu
@@ -39525,9 +39490,9 @@ wnO
 jOK
 sgb
 uch
-nFf
-pbp
-jfK
+vfB
+uHQ
+vsD
 wXB
 uqz
 fhl
@@ -39590,13 +39555,13 @@ lsq
 dTw
 kWc
 uch
-nFf
-pbp
-pbp
-pbp
-pbp
-pbp
-jfK
+vfB
+lMO
+uHQ
+mcm
+uHQ
+lMO
+vsD
 wXB
 pxS
 iha
@@ -39612,9 +39577,9 @@ wLo
 afX
 pSg
 tfL
-nFf
+vfB
 eVc
-pbp
+vsD
 gsT
 ezi
 ezi
@@ -39756,8 +39721,8 @@ eFL
 jOK
 cjT
 uch
-nFf
-iqb
+lHY
+vsD
 tEC
 rZh
 rcr
@@ -39769,7 +39734,7 @@ pVF
 rZh
 uch
 nFf
-jfK
+lMO
 wXB
 jOK
 vmv
@@ -39782,9 +39747,9 @@ jKy
 jOK
 sgb
 uch
-nFf
-pbp
-jfK
+vfB
+lMO
+vsD
 wXB
 nvY
 iNc
@@ -39821,7 +39786,7 @@ hLa
 hLa
 hLa
 uca
-eUM
+ceg
 vuD
 dbu
 dbu
@@ -39847,13 +39812,13 @@ lsq
 lsq
 kWc
 uch
-nFf
-pbp
-pbp
-rsF
-pbp
+vfB
+lMO
+uHQ
+kRp
+lMO
 ubI
-jfK
+vsD
 wXB
 ddT
 iha
@@ -39869,9 +39834,9 @@ pVF
 xSq
 sgb
 tfL
-nFf
-ugw
-pbp
+lHY
+umW
+vsD
 gsT
 pSg
 ezi
@@ -40014,7 +39979,7 @@ jOK
 cjT
 uch
 nFf
-uHQ
+vsD
 xuU
 fJq
 xwS
@@ -40039,9 +40004,9 @@ qta
 jOK
 sgb
 uch
-nFf
-pbp
-jfK
+lHY
+lMO
+vsD
 wXB
 nvY
 iNc
@@ -40104,13 +40069,13 @@ lsq
 lsq
 kWc
 uch
-nFf
-pbp
-pbp
-rsF
-pbp
-pbp
-jfK
+vfB
+lMO
+lMO
+kRp
+lMO
+lMO
+vsD
 wXB
 uch
 iha
@@ -40127,8 +40092,8 @@ afX
 sgb
 tfL
 nFf
-pbp
-xJk
+uHQ
+tUF
 gsT
 xWL
 sgb
@@ -40271,7 +40236,7 @@ jOK
 lsq
 uch
 nFf
-uHQ
+jfK
 wXB
 fJq
 xwS
@@ -40297,8 +40262,8 @@ jOK
 mzI
 uch
 nFf
-pbp
 lMO
+vsD
 wXB
 nvY
 uQk
@@ -40361,12 +40326,12 @@ lsq
 lsq
 kWc
 gSO
-nFf
-pbp
-pbp
-rsF
-pbp
-pbp
+lHY
+lMO
+lMO
+kRp
+lMO
+lMO
 jfK
 wXB
 uch
@@ -40384,8 +40349,8 @@ afX
 xWL
 tfL
 nFf
-pbp
-pbp
+lMO
+vsD
 gsT
 xWL
 sgb
@@ -40528,7 +40493,7 @@ jOK
 wvb
 uch
 nFf
-lMO
+jfK
 wXB
 fJq
 pVF
@@ -40553,9 +40518,9 @@ jOK
 vaG
 mzI
 uch
-nFf
-pbp
-jfK
+qhK
+lMO
+vsD
 wXB
 nvY
 jdJ
@@ -40620,10 +40585,10 @@ dtL
 hSU
 nFf
 pbp
-pbp
-rsF
-pbp
-pbp
+lMO
+jWr
+lMO
+lMO
 jfK
 wXB
 uch
@@ -40641,8 +40606,8 @@ ezi
 ezi
 tfL
 nFf
-pbp
-pbp
+lMO
+jfK
 gsT
 ezi
 ezi
@@ -40785,7 +40750,7 @@ wvb
 cjT
 uch
 pkQ
-lMO
+vsD
 wXB
 fJq
 nlE
@@ -40810,9 +40775,9 @@ kRY
 xfM
 mzI
 uch
-nFf
-pbp
-jfK
+qhK
+lMO
+vsD
 wXB
 nvY
 jdJ
@@ -40877,9 +40842,9 @@ wXB
 uch
 nFf
 pbp
-pbp
+lMO
 bgq
-pbp
+lMO
 pbp
 jfK
 wXB
@@ -40899,7 +40864,7 @@ gFd
 vDD
 nFf
 pbp
-pbp
+jfK
 dKP
 gFd
 uhx
@@ -41042,7 +41007,7 @@ hDr
 wha
 ipp
 vfB
-lMO
+vsD
 ecA
 fJq
 oHU
@@ -41053,7 +41018,7 @@ pVF
 pVF
 fJq
 ltk
-nFf
+pkQ
 jfK
 wXB
 jOK
@@ -41067,9 +41032,9 @@ vcC
 xfM
 mzI
 uch
-nFf
+qhK
 pbp
-jfK
+vsD
 wXB
 nvY
 ceg
@@ -41113,7 +41078,7 @@ uhW
 ceg
 ceg
 eRw
-eUM
+ceg
 gFf
 cVr
 cVr
@@ -41124,19 +41089,19 @@ ceg
 ceg
 ceg
 ceg
-eUM
 ceg
 ceg
 ceg
 ceg
-eUM
+ceg
+ceg
 wXB
 uch
 nFf
 pbp
-pbp
+lMO
 rIX
-pbp
+lMO
 pbp
 jfK
 wXB
@@ -41150,16 +41115,16 @@ kmn
 kmn
 wXB
 uch
-nFf
+frg
+pDT
+pDT
+pDT
 pbp
 pbp
 pbp
-pbp
-pbp
-pbp
-pbp
-pbp
-pbp
+pDT
+pDT
+pDT
 saU
 mgf
 pDT
@@ -41168,7 +41133,7 @@ pDT
 jAt
 pDT
 pDT
-pbp
+pDT
 wXB
 qZx
 "}
@@ -41299,7 +41264,7 @@ bBv
 wha
 fTO
 vfB
-uHQ
+vsD
 wXB
 fJq
 oHU
@@ -41310,7 +41275,7 @@ nlE
 pVF
 fJq
 uch
-nFf
+vfB
 jfK
 wXB
 jOK
@@ -41324,9 +41289,9 @@ vcC
 xfM
 sgb
 uch
-nFf
+qhK
 pbp
-jfK
+vsD
 wXB
 nvY
 ceg
@@ -41390,10 +41355,10 @@ ceg
 wXB
 uch
 nFf
-pbp
-pbp
+lMO
+lMO
 rLO
-pbp
+lMO
 pbp
 jfK
 wXB
@@ -41556,7 +41521,7 @@ bBv
 wha
 ddT
 vfB
-uHQ
+vsD
 wXB
 mhS
 cnL
@@ -41567,7 +41532,7 @@ nlE
 iVW
 mhS
 uch
-nFf
+vfB
 jfK
 wXB
 jOK
@@ -41581,9 +41546,9 @@ kRY
 xfM
 sgb
 uch
-nFf
+qhK
 pbp
-jfK
+vsD
 wXB
 nvY
 kEs
@@ -41647,11 +41612,11 @@ ceg
 wXB
 uch
 nFf
-pbp
-pbp
-rsF
-pbp
-pbp
+lMO
+lMO
+jWr
+lMO
+lMO
 jfK
 sli
 ddT
@@ -41813,7 +41778,7 @@ bBv
 vgk
 uch
 lHY
-lMO
+vsD
 wXB
 afX
 dJK
@@ -41824,7 +41789,7 @@ fPk
 fPk
 afX
 uch
-nFf
+lHY
 jfK
 ubM
 jOK
@@ -41838,9 +41803,9 @@ jOK
 vaG
 hUu
 gSO
-nFf
+qhK
 pbp
-jfK
+vsD
 wXB
 nvY
 jcl
@@ -41904,12 +41869,12 @@ ruW
 wXB
 uch
 nFf
-pbp
-pbp
-rsF
-pbp
-pbp
-jfK
+lMO
+lMO
+jWr
+lMO
+lMO
+vsD
 tEC
 uch
 iha
@@ -41937,8 +41902,8 @@ pbp
 pbp
 lMO
 pbp
-pbp
-pbp
+lMO
+lMO
 jfK
 wXB
 qZx
@@ -42070,7 +42035,7 @@ bBv
 sfe
 uch
 nFf
-pbp
+jfK
 dKP
 boQ
 boQ
@@ -42086,10 +42051,10 @@ pbp
 dKP
 boQ
 boQ
-dou
 boQ
 boQ
-dou
+boQ
+boQ
 boQ
 hrR
 boQ
@@ -42161,12 +42126,12 @@ ceg
 wXB
 uch
 nFf
-pbp
-pbp
-rsF
-pbp
-pbp
-jfK
+lMO
+lMO
+jWr
+uHQ
+lMO
+vsD
 xuU
 uch
 iha
@@ -42191,10 +42156,10 @@ pbp
 lMO
 pbp
 pbp
-pbp
-pbp
-pbp
-pbp
+lMO
+lMO
+lMO
+lMO
 pbp
 jfK
 wXB
@@ -42328,7 +42293,7 @@ dgH
 uch
 nFf
 pbp
-pbp
+pDT
 pDT
 pDT
 pDT
@@ -42342,11 +42307,11 @@ pbp
 pbp
 pbp
 pDT
-pDT
-pDT
-pDT
-pDT
-pDT
+oxW
+oxW
+oxW
+oxW
+oxW
 pDT
 vSf
 pDT
@@ -42404,7 +42369,7 @@ ceg
 lVT
 kzz
 ubN
-eUM
+ceg
 ceg
 lVT
 kmn
@@ -42418,12 +42383,12 @@ ceg
 wXB
 uch
 qhK
-pbp
-pbp
-rsF
-pbp
-pbp
-jfK
+lMO
+lMO
+jWr
+uHQ
+lMO
+vsD
 wXB
 uch
 hDr
@@ -42448,10 +42413,10 @@ pbp
 pbp
 pbp
 pbp
-pbp
-pbp
+lMO
+lMO
 aai
-pbp
+lMO
 pbp
 jfK
 wXB
@@ -42585,32 +42550,32 @@ dgH
 uch
 nFf
 pbp
-pbp
-pbp
-pbp
-lMO
-lMO
-lMO
-pbp
-pbp
+ejl
+ejl
+ejl
+ejl
+ejl
+ejl
+ejl
+xAm
 cuH
 pbp
 lMO
 lMO
 pbp
-pbp
-pbp
-pbp
-lMO
-lMO
-lMO
-pbp
-pbp
-pbp
+ejl
+ejl
+ejl
+rHP
+rHP
+ejl
+ejl
+ejl
+xAm
 cuH
 iBU
 tHr
-mLl
+pbp
 jfK
 wXB
 nvY
@@ -42676,11 +42641,11 @@ qzI
 uch
 qhK
 pbp
-pbp
-rsF
-pbp
-pbp
-jfK
+lMO
+jWr
+uHQ
+uHQ
+vsD
 wXB
 aXE
 pRt
@@ -42705,9 +42670,9 @@ lMO
 pbp
 pbp
 lMO
-pbp
-pbp
-pbp
+lMO
+lMO
+lMO
 pbp
 pbp
 jfK
@@ -42857,11 +42822,11 @@ iqb
 pbp
 snq
 snq
-snq
-snq
-snq
-snq
-snq
+duo
+duo
+duo
+duo
+duo
 snq
 snq
 cuH
@@ -42933,11 +42898,11 @@ lsq
 uch
 qhK
 pbp
-pbp
-rsF
-pbp
-pbp
-jfK
+lMO
+jWr
+uHQ
+uHQ
+vsD
 dKP
 boQ
 boQ
@@ -42961,10 +42926,10 @@ pbp
 vMJ
 pbp
 pbp
-dwu
+lMO
 lMO
 pbp
-pbp
+lMO
 pbp
 pbp
 jfK
@@ -43115,7 +43080,7 @@ oKA
 jWt
 jWt
 jWt
-gmO
+jWt
 jWt
 jWt
 jWt
@@ -43125,7 +43090,7 @@ nvm
 wla
 nFf
 pbp
-jfK
+vsD
 wXB
 nvY
 ceg
@@ -43190,19 +43155,19 @@ pHs
 uch
 nFf
 pbp
-pbp
-yah
-pbp
-pbp
-pbp
+lMO
+jWr
+uHQ
+lMO
+lMO
 pDT
-pDT
-pbp
-pDT
-pDT
-pDT
-pDT
-pDT
+oxW
+oxW
+oxW
+oxW
+oxW
+oxW
+oxW
 pDT
 qlM
 pDT
@@ -43221,7 +43186,7 @@ pbp
 lMO
 pbp
 pbp
-pbp
+lMO
 lMO
 pbp
 pbp
@@ -43376,13 +43341,13 @@ pSg
 sgb
 sgb
 pSg
-hRu
+lsq
 lsq
 uaM
 uZK
 nFf
 pbp
-jfK
+vsD
 wXB
 tIh
 fda
@@ -43449,20 +43414,20 @@ nFf
 pbp
 pbp
 jWr
-pbp
-pbp
-fit
-pbp
-pbp
-pbp
-pbp
-pbp
-pbp
-pbp
+uHQ
 lMO
-iBU
-cuH
 pbp
+pmU
+pmU
+ejl
+rHP
+rHP
+ejl
+pmU
+pmU
+pmU
+cuH
+pmU
 pbp
 pbp
 lMO
@@ -43637,10 +43602,10 @@ qhp
 qhp
 vuD
 uch
-nFf
+igi
 pbp
-jfK
-owL
+vsD
+wXB
 bhJ
 fda
 ceg
@@ -43698,7 +43663,7 @@ xgT
 uch
 nFf
 thC
-pbp
+lMO
 jfK
 wXB
 uch
@@ -43706,20 +43671,20 @@ nFf
 pbp
 lMO
 jWr
-pbp
-pbp
-pbp
-pbp
-pbp
-pbp
-pbp
-pbp
-pbp
 lMO
 lMO
-lMO
+pbp
+pmU
+ejl
+ejl
+ejl
+ejl
+ejl
+ejl
+ejl
+pmU
 cuH
-pbp
+pmU
 pbp
 pbp
 pbp
@@ -43894,9 +43859,9 @@ csn
 xWz
 vuD
 uch
-nFf
+vfB
 pbp
-jfK
+vsD
 wXB
 jBm
 fda
@@ -43953,9 +43918,9 @@ cBd
 xYA
 xgT
 uch
-lCk
-bwc
-tjK
+tQy
+yah
+lho
 jfK
 wXB
 uch
@@ -43963,7 +43928,7 @@ nFf
 thC
 lMO
 hFq
-pbp
+lMO
 pbp
 pbp
 snq
@@ -43994,8 +43959,8 @@ snq
 snq
 snq
 duo
-pbp
-pbp
+snq
+snq
 wXB
 qZx
 "}
@@ -44151,9 +44116,9 @@ csn
 ura
 vuD
 uch
-wWs
+vfB
 pbp
-jfK
+vsD
 wXB
 uqz
 fda
@@ -44211,14 +44176,14 @@ bEN
 cph
 lSq
 sRD
-pbp
-pbp
-jfK
+lMO
+lMO
+vsD
 wXB
 uch
 nFf
-pbp
-vMJ
+lMO
+lMO
 hsU
 lMO
 pbp
@@ -44408,7 +44373,7 @@ fhz
 eWp
 dOf
 uch
-nFf
+vfB
 pbp
 jfK
 wXB
@@ -44467,18 +44432,18 @@ cBd
 iEf
 xbR
 uch
-nFf
-pbp
-pbp
-jfK
+qhK
+lMO
+uHQ
+vsD
 wXB
 uch
 nFf
-pbp
+lMO
 uHQ
 rIX
 pnh
-pbp
+lMO
 jfK
 wXB
 yeV
@@ -44665,7 +44630,7 @@ csn
 eWp
 dOf
 uch
-nFf
+kZw
 lMO
 jfK
 wXB
@@ -44724,18 +44689,18 @@ cBd
 dpt
 xgT
 uch
-wrZ
-bwc
-tjK
-jfK
+sSf
+yah
+inJ
+vsD
 wXB
 uch
 nFf
 raT
-tHr
+lMO
 rIX
-pbp
-pbp
+lMO
+lMO
 jfK
 wXB
 uch
@@ -44981,18 +44946,18 @@ cBd
 dwr
 xgT
 uch
-nFf
-pbp
-pbp
-jfK
+vfB
+uHQ
+uHQ
+vsD
 wXB
 uch
 nFf
 pbp
-vMJ
+lMO
 rIX
-pbp
-pbp
+lMO
+lMO
 jfK
 wXB
 uch
@@ -45238,18 +45203,18 @@ rXe
 bEN
 xgT
 uch
-nFf
-pbp
-pbp
-xJk
+qhK
+lMO
+uHQ
+tUF
 wXB
 uch
 nFf
 eKn
 tOS
 hsU
-pbp
-pbp
+lMO
+lMO
 jfK
 sli
 uch
@@ -45258,7 +45223,7 @@ ceg
 ceg
 kEs
 xHj
-eUM
+ceg
 ceg
 ibu
 lsq
@@ -45436,9 +45401,9 @@ gDI
 eSV
 vuD
 uch
-nFf
+qhK
 pbp
-xcb
+jfK
 wXB
 nvY
 jdJ
@@ -45495,23 +45460,23 @@ cBd
 cBd
 xbR
 uch
-wrZ
+gnT
 kkl
-tjK
-jfK
+inJ
+vsD
 dNs
 mKR
 nFf
 pbp
 tHr
-xpw
-pbp
+jWr
+lMO
 sBu
 jfK
 tEC
 uch
 ceg
-eUM
+ceg
 ceg
 lVT
 kzz
@@ -45693,9 +45658,9 @@ xSM
 xSM
 vuD
 uch
-nFf
+qhK
 pbp
-lMO
+jfK
 wXB
 nvY
 dzP
@@ -45752,17 +45717,17 @@ cBd
 eoB
 oQK
 uch
-nFf
-pbp
-pbp
-jfK
+qhK
+lMO
+lMO
+vsD
 kLm
 rfK
 nFf
 pbp
 pbp
 rLO
-pbp
+lMO
 pbp
 jfK
 tEC
@@ -45950,7 +45915,7 @@ bde
 eJV
 vuD
 uch
-nFf
+qhK
 pbp
 jfK
 wXB
@@ -45998,7 +45963,7 @@ hLa
 hLa
 hLa
 hLa
-vdd
+uca
 ceg
 xbR
 vnn
@@ -46009,8 +45974,8 @@ cBd
 cBd
 dOV
 sgI
-nFf
-pbp
+qhK
+lMO
 lMO
 pbp
 pDT
@@ -46206,9 +46171,9 @@ bde
 bde
 bde
 vuD
-wAF
+uch
 nFf
-jfK
+pbp
 xJk
 wXB
 nvY
@@ -46267,11 +46232,11 @@ dFs
 xbR
 uch
 nFf
-pbp
 lMO
 lMO
-pbp
-pbp
+pmU
+pmU
+pmU
 pbp
 pbp
 pbp
@@ -46523,7 +46488,7 @@ xbR
 xbR
 xbR
 uch
-nFf
+ubC
 duo
 duo
 duo
@@ -46779,7 +46744,7 @@ wXB
 lsq
 lsq
 lsq
-lsq
+aXE
 jWt
 jWt
 jWt
@@ -47047,7 +47012,7 @@ nFf
 lMO
 pbp
 aYy
-kaz
+lMO
 lMO
 jfK
 giD
@@ -47222,7 +47187,7 @@ boQ
 boQ
 vDD
 nFf
-pbp
+jfK
 dKP
 cVk
 boQ
@@ -47232,7 +47197,7 @@ boQ
 boQ
 boQ
 boQ
-boQ
+vfB
 boQ
 vDD
 nFf
@@ -47260,19 +47225,19 @@ hLa
 hLa
 vbY
 cZd
-mmB
-mmB
-mmB
+vbY
+vbY
+hLa
 jmU
 hLa
 hLa
 hLa
 hLa
 hLa
-hPH
-mmB
-mmB
-mmB
+hLa
+vbY
+vbY
+vbY
 qCY
 vbY
 hLa
@@ -47304,7 +47269,7 @@ nFf
 lMO
 pbp
 mcm
-ugw
+lMO
 ubO
 jfK
 giD
@@ -47453,44 +47418,44 @@ oWz
 pDT
 pDT
 pDT
+oxW
+fWJ
+fWJ
+fWJ
+oxW
+oxW
 pDT
 pDT
+oxW
+oxW
+oxW
 pDT
-pDT
-pDT
-wlA
-pDT
-pDT
-pDT
-pDT
-pDT
-wlA
 pDT
 cuH
 vUG
-vUG
+yff
+oxW
+oxW
+pDT
+cuH
+pDT
+oxW
+oxW
+oxW
+pDT
+xAm
+xAm
+pbp
+pDT
+pDT
+pDT
+oxW
+oxW
+oxW
 pDT
 pDT
 pDT
 cuH
-pDT
-pbp
-pbp
-pbp
-lMO
-lMO
-pbp
-pbp
-pDT
-pDT
-pDT
-pDT
-pDT
-pDT
-pDT
-pDT
-pDT
-cuH
 lMO
 lMO
 lMO
@@ -47500,10 +47465,10 @@ cuH
 pDT
 pDT
 pDT
-pDT
-pDT
-pDT
-pDT
+saU
+fWJ
+fWJ
+mgf
 pDT
 pDT
 pDT
@@ -47514,35 +47479,35 @@ nMX
 mVa
 mVa
 mVa
+bTX
+bgZ
+fxB
+nMX
 mVa
-knO
-vUG
-oxW
-ucF
-taX
-ogI
-hLa
-hLa
-hLa
-hLa
-hLa
-ieG
-ucF
-ucF
-wlA
+mVa
+mVa
+mVa
+mVa
+mVa
+mVa
+cOK
+bgZ
+bgZ
+mVa
+mVa
 bdE
 mVa
 mVa
 bTX
 bgZ
-dev
+nMX
 mVa
 mVa
 mVa
 mVa
 gdq
 pDT
-wlA
+pDT
 pDT
 pDT
 vSf
@@ -47559,9 +47524,9 @@ pDT
 pDT
 pbp
 lMO
-pbp
+lMO
 ubO
-pbp
+lMO
 pbp
 jfK
 giD
@@ -47704,49 +47669,49 @@ jLg
 jLg
 jLg
 rlz
-gnT
 vMc
 vMc
-pbp
-pbp
-pbp
-pbp
-lMO
+vMc
+xAm
+ejl
+ejl
+ejl
+ejl
 iqb
-pbp
-pbp
-pbp
-pbp
-pbp
-pbp
-pbp
-pbp
-pbp
-vrA
+rHP
+rHP
+ejl
+ejl
+ejl
+ejl
+ejl
+xAm
+xAm
+fYQ
 eGF
-mwd
-vMJ
-pbp
-pbp
-pbp
+fYQ
+ejl
+rHP
+rHP
+ejl
 eGF
-pbp
-pbp
-pbp
-lMO
-uHQ
-lMO
-pbp
+ejl
+ejl
+rHP
+ejl
+ejl
+ejl
+ejl
 iqb
-mRP
-pbp
-pbp
-pbp
-pbp
-pbp
-pbp
-pbp
-pbp
+xAm
+xAm
+ejl
+ejl
+rHP
+ejl
+xAm
+xAm
+xAm
 cuH
 mRP
 lMO
@@ -47754,53 +47719,53 @@ lMO
 pbp
 pbp
 cuH
-pbp
-pbp
-pbp
-pbp
-pbp
-pbp
-pbp
-pbp
-pbp
-pbp
+ejl
+ejl
+rHP
+rHP
+ejl
+ejl
+ejl
 xAm
 xAm
 xAm
+xAm
+ejl
+ejl
 ejl
 rHP
 rHP
 jxo
 pmU
-pmU
-pmU
-xrI
-pmU
-uxg
-ogI
-hLa
-hLa
-hLa
-hLa
-hLa
-ieG
-cAq
-xth
-pmU
+ejl
+fYQ
+ejl
+ejl
+rHP
+ejl
+ejl
+ejl
+rHP
+rHP
+wgD
+rHP
+ejl
+ejl
+ucF
 vak
 pmU
+ejl
+ejl
+ejl
+ejl
+ejl
+ejl
+rHP
+rHP
+ejl
+ejl
 pmU
-pmU
-pmU
-pmU
-pmU
-pmU
-pmU
-pmU
-pmU
-pmU
-pmU
-pbp
+ejl
 jxo
 xAm
 sQC
@@ -47808,17 +47773,17 @@ pmU
 oXe
 xrI
 pmU
+pmU
+pmU
+pmU
+pmU
+pmU
+pmU
 lMO
-pmU
-pmU
-pmU
-pmU
-pmU
-pbp
 ubO
-pbp
 lMO
-ejl
+lMO
+lMO
 pbp
 xzm
 giD
@@ -47961,49 +47926,49 @@ jLg
 jLg
 jLg
 rlz
-gnT
 vMc
 vMc
-pbp
-pbp
-pbp
-xcb
-lMO
-lMO
-pbp
-pbp
-pbp
-pbp
-pbp
-pbp
-pbp
-pbp
-lMO
-mwd
+vMc
+xAm
+xAm
+ejl
+rHP
+rHP
+ejl
+ejl
+ejl
+ejl
+rHP
+rHP
+ejl
+xAm
+ejl
+ejl
+fYQ
 qlM
 iqb
-lMO
-pbp
+rHP
+rHP
 bzE
-pbp
+ejl
 qlM
-pbp
-pbp
-pbp
-lMO
-uHQ
-lMO
-lMO
-tHr
-tHr
-pbp
-pbp
-pbp
-pbp
-pbp
-pbp
-pbp
-pbp
+xAm
+ejl
+rHP
+rHP
+rHP
+ejl
+xAm
+xAm
+ejl
+ejl
+rHP
+rHP
+rHP
+rHP
+xAm
+ejl
+xAm
 cuH
 tHr
 dwY
@@ -48011,53 +47976,53 @@ lMO
 lMO
 pbp
 cuH
-lMO
-lMO
-pbp
-pbp
-pbp
-pbp
-pbp
-pbp
-pbp
-pbp
+xAm
+ejl
+ejl
+ejl
+ejl
+rHP
+ejl
+ejl
+ejl
 xAm
 xAm
 xAm
-xAm
+ejl
+ejl
 ejl
 jxo
-pmU
+ejl
 pmU
 pmU
 ejl
-pmU
-xrI
-mIZ
-txU
-hLa
-hLa
-hLa
-hLa
-hLa
-ieG
-pmU
+ejl
+rHP
+rHP
+rHP
+ejl
+ejl
+fYQ
+rHP
+rHP
+ejl
+ejl
+rHP
+rHP
 ucF
-brC
 pmU
-ycP
-pmU
-pYB
-pmU
-pmU
-pmU
+ejl
+mFt
+ejl
+ejl
+ejl
 ejl
 rHP
 rHP
 jxo
-pmU
+ejl
 pYB
-lMO
+ejl
 uHQ
 jxo
 pmU
@@ -48065,18 +48030,18 @@ pmU
 jzp
 xrI
 pmU
-lMO
-lMO
+pmU
+pmU
+pmU
+pmU
 pmU
 pmU
 lMO
-pmU
-pbp
 lMO
-pbp
-ejl
-ejl
-pbp
+lMO
+lMO
+lMO
+lMO
 jfK
 giD
 aQW
@@ -48222,27 +48187,27 @@ qdy
 qdy
 qdy
 snq
-snq
-snq
-snq
-snq
-snq
-snq
-snq
-snq
-snq
-snq
-vcS
-snq
+duo
+duo
+duo
+qpZ
+qpZ
+duo
+duo
+qpZ
+qpZ
+duo
+duo
+duo
 snq
 snq
 iTG
 cuH
-iTG
-pbp
-pbp
-lMO
-pbp
+uKx
+ejl
+ejl
+ejl
+snq
 cuH
 snq
 duo
@@ -48254,10 +48219,10 @@ duo
 snq
 snq
 snq
-snq
-snq
-snq
-snq
+duo
+duo
+duo
+duo
 duo
 duo
 duo
@@ -48270,10 +48235,10 @@ pbp
 cuH
 duo
 snq
-snq
-snq
-snq
-snq
+duo
+duo
+duo
+duo
 ijK
 bFx
 flZ
@@ -48288,20 +48253,20 @@ wAf
 uet
 uet
 qrj
-fZh
-tJu
-ogI
-hLa
-hLa
-hLa
-hLa
-hLa
-hLa
-pCI
-jOG
-vLR
-snq
-snq
+kaz
+uet
+cqK
+cqK
+cqK
+cqK
+wmB
+uet
+uet
+uet
+uet
+uHw
+cqK
+ygY
 uet
 uHw
 eDK
@@ -48309,14 +48274,14 @@ wAf
 uet
 uet
 uet
-fxB
+uet
 uet
 nmM
 snq
 kgo
 raJ
 qpZ
-iZs
+ygY
 snq
 snq
 fKt
@@ -48329,15 +48294,15 @@ snq
 snq
 snq
 duo
-pbp
-pbp
-pbp
+lMO
+lMO
+lMO
 tIj
-raM
+uQE
 vro
 giD
 aQW
-xAc
+oeV
 jjr
 jjr
 jjr
@@ -48497,8 +48462,8 @@ fCH
 ogf
 cEd
 kQH
-pbp
-pbp
+lMO
+vsD
 oKA
 jWt
 jWt
@@ -48522,7 +48487,7 @@ jWt
 ltk
 nFf
 lMO
-pbp
+jfK
 oKA
 jWt
 jWt
@@ -48545,8 +48510,8 @@ hLa
 vbY
 vCT
 cZd
-mFt
-mFt
+vbY
+vbY
 txU
 hLa
 hLa
@@ -48555,9 +48520,9 @@ hLa
 hLa
 hLa
 hLa
-pCI
-mFt
-mFt
+hLa
+vbY
+vbY
 wFo
 vCT
 hLa
@@ -48594,8 +48559,8 @@ aRt
 aRt
 aRt
 aQW
-xAc
-xAc
+oeV
+oeV
 aRt
 jyh
 uAm
@@ -48754,8 +48719,8 @@ vDu
 cVa
 vDD
 nFf
-pbp
-jfK
+uHQ
+vsD
 wXB
 yeV
 boQ
@@ -48779,7 +48744,7 @@ lsq
 mKR
 nFf
 pbp
-pbp
+jfK
 wXB
 yeV
 boQ
@@ -48843,18 +48808,18 @@ xTH
 xTH
 aLn
 hgd
-qjT
+bYc
 jXh
 aRt
 jXh
 jXh
 jXh
 mZJ
-xAc
-xAc
-xAc
-ghE
-xAc
+oeV
+oeV
+wHY
+oeV
+oeV
 iKp
 nkj
 nkj
@@ -49010,9 +48975,9 @@ pDT
 pDT
 onS
 pbp
-pbp
-pbp
-jfK
+lMO
+uHQ
+vsD
 wXB
 lSK
 xcY
@@ -49036,7 +49001,7 @@ dNs
 mKR
 nFf
 lMO
-lMO
+jfK
 wXB
 uch
 rdq
@@ -49100,18 +49065,18 @@ cJK
 blh
 uDV
 hgd
-qjT
+bYc
 jXh
 wfq
 jXh
 jXh
 jXh
 vZy
-xAc
-xAc
-ghE
-ghE
-xAc
+oeV
+wHY
+cAB
+wHY
+oeV
 aRt
 jjr
 fHq
@@ -49267,9 +49232,9 @@ pbp
 pbp
 xnk
 pbp
-pbp
-pbp
-jfK
+lMO
+uHQ
+vsD
 wXB
 cnu
 sxy
@@ -49293,7 +49258,7 @@ wXB
 uch
 nFf
 pbp
-pbp
+jfK
 wXB
 uch
 ceg
@@ -49364,11 +49329,11 @@ jXh
 jXh
 jXh
 vZy
-xAc
-xAc
-ghE
-xAc
-xAc
+oeV
+wHY
+cAB
+wHY
+oeV
 cAB
 lLP
 gDK
@@ -49525,8 +49490,8 @@ snq
 pAv
 raB
 pbp
-pbp
-jfK
+lMO
+vsD
 wXB
 cxo
 ceg
@@ -49550,7 +49515,7 @@ wXB
 uch
 nFf
 lMO
-lMO
+jfK
 wXB
 uch
 ceg
@@ -49600,7 +49565,7 @@ mPU
 qto
 qaI
 qto
-nID
+qto
 kkI
 gFv
 xAc
@@ -49622,10 +49587,10 @@ jXh
 jXh
 vZy
 ogP
-ghE
-ghE
-xAc
-xAc
+oeV
+wHY
+wHY
+oeV
 xAc
 xAc
 xAc
@@ -49807,7 +49772,7 @@ sli
 uch
 nFf
 lMO
-lMO
+jfK
 wXB
 uch
 ceg
@@ -49878,10 +49843,10 @@ jXh
 jXh
 jXh
 aRt
-xAc
-xAc
-ghE
-xAc
+oeV
+oeV
+oeV
+oeV
 xYk
 oQH
 oQH
@@ -50038,9 +50003,9 @@ wXB
 sfe
 dNl
 uch
-nFf
-pbp
-jfK
+ubC
+snq
+snq
 wXB
 nqM
 nSB
@@ -50093,7 +50058,7 @@ hLa
 hLa
 hLa
 hLa
-cAq
+hLa
 hLa
 hLa
 hLa
@@ -50137,8 +50102,8 @@ qCw
 aRt
 icV
 ovZ
-xAc
-xAc
+xpw
+oeV
 bfd
 rvl
 sik
@@ -50290,7 +50255,7 @@ lMO
 pbp
 fxD
 uHQ
-ykS
+uka
 wXB
 sfe
 vDu
@@ -50344,7 +50309,7 @@ hLa
 hLa
 hLa
 hLa
-cAq
+hLa
 hLa
 hLa
 hLa
@@ -50395,7 +50360,7 @@ jXh
 jXh
 ykB
 mUf
-xAc
+oeV
 gMe
 nYb
 nYb
@@ -50547,7 +50512,7 @@ lMO
 pbp
 pbp
 lMO
-jfK
+vsD
 wXB
 sfe
 weA
@@ -50605,7 +50570,7 @@ hLa
 hLa
 hLa
 hLa
-ucF
+hLa
 hLa
 hLa
 hLa
@@ -50624,7 +50589,7 @@ hLa
 eWC
 eWC
 mPU
-nID
+qto
 qto
 qto
 qto
@@ -50652,7 +50617,7 @@ jXh
 jXh
 ykB
 mUf
-xAc
+oeV
 gMe
 nYb
 ajL
@@ -50804,7 +50769,7 @@ lMO
 pbp
 pbp
 lMO
-jfK
+vsD
 wXB
 sfe
 fGC
@@ -50865,7 +50830,7 @@ hLa
 hLa
 hLa
 hLa
-ucF
+hLa
 hLa
 hLa
 hLa
@@ -50909,7 +50874,7 @@ jXh
 gaL
 ykB
 mUf
-xAc
+oeV
 gMe
 cMJ
 xlH
@@ -51060,8 +51025,8 @@ uHQ
 uHQ
 pbp
 pbp
-jfK
-jfK
+pbp
+vsD
 wXB
 sfe
 sfe
@@ -51118,9 +51083,9 @@ hLa
 hLa
 hLa
 hLa
-ucF
-ucF
-ucF
+hLa
+hLa
+hLa
 hLa
 hLa
 hLa
@@ -51166,7 +51131,7 @@ jXh
 jXh
 ykB
 mUf
-xAc
+oeV
 kQg
 cMJ
 cMJ
@@ -51317,8 +51282,8 @@ lMO
 uHQ
 lMO
 pbp
-jfK
-jfK
+pbp
+vsD
 wXB
 sfe
 sfe
@@ -51376,9 +51341,9 @@ hLa
 hLa
 hLa
 hLa
-ucF
 hLa
-ucF
+hLa
+hLa
 hLa
 hLa
 hLa
@@ -51398,7 +51363,7 @@ iDy
 qto
 hxq
 qto
-nID
+qto
 qto
 kkI
 eeQ
@@ -51423,7 +51388,7 @@ gaL
 jXh
 ykB
 pSl
-xAc
+oeV
 bfd
 lvB
 tUg
@@ -51574,7 +51539,7 @@ uHQ
 lMO
 lMO
 pbp
-jfK
+pbp
 jfK
 wXB
 sfe
@@ -51831,7 +51796,7 @@ mGH
 lMO
 lMO
 pbp
-jfK
+pbp
 jfK
 wXB
 sfe
@@ -51895,7 +51860,7 @@ hLa
 hLa
 hLa
 hLa
-brC
+hLa
 hLa
 hLa
 hLa
@@ -51935,7 +51900,7 @@ jqi
 jXh
 gaL
 jXh
-ykB
+jXh
 nTc
 nTc
 nTc
@@ -52144,7 +52109,7 @@ hLa
 hLa
 hLa
 hLa
-brC
+hLa
 hLa
 hLa
 hLa
@@ -52192,15 +52157,15 @@ jqi
 jXh
 jXh
 jXh
-ykB
+jXh
 gVr
-gaL
-jXh
-jXh
-kZw
-jXh
+gVr
+gVr
+gVr
+gVr
+gVr
 lWS
-jXh
+ykB
 mUf
 xAc
 xAc
@@ -52339,12 +52304,12 @@ vAN
 wag
 bQk
 uch
-nFf
+ubC
 snq
 snq
-pbp
-pbp
-pbp
+snq
+snq
+snq
 snq
 snq
 wXB
@@ -52405,7 +52370,7 @@ hLa
 hLa
 hLa
 hLa
-cAq
+hLa
 hLa
 hLa
 hLa
@@ -52425,7 +52390,7 @@ mPU
 iDy
 qto
 qto
-nID
+qto
 qto
 qto
 kkI
@@ -52449,14 +52414,14 @@ jqi
 jXh
 jXh
 gaL
-ykB
-gVr
-gaL
-kZw
-gaL
-gVr
-vsD
 jXh
+gVr
+gVr
+gVr
+gVr
+gVr
+gVr
+gVr
 wTV
 mUf
 xAc
@@ -52706,15 +52671,15 @@ jqi
 jXh
 jXh
 gaL
-ykB
-gVr
-gaL
-gaL
-gaL
-gVr
-vsD
 jXh
-gaL
+gVr
+gVr
+gVr
+gVr
+gVr
+gVr
+gVr
+ykB
 mUf
 xAc
 xAc
@@ -52935,7 +52900,7 @@ hLa
 hLa
 hLa
 mPU
-nID
+qto
 qto
 qto
 qto
@@ -52961,15 +52926,15 @@ hPK
 gaL
 kjL
 jXh
+gaL
+gaL
 jXh
-jXh
-ykB
-gaL
-gaL
-gaL
-kZw
 gVr
-gaL
+gVr
+gVr
+gVr
+gVr
+gVr
 hFQ
 cTQ
 mUf
@@ -53218,17 +53183,17 @@ hPK
 gaL
 kjL
 jXh
-jXh
 gaL
+gaL
+jXh
+gVr
+gVr
+gVr
+gVr
+gVr
+gVr
+gVr
 ykB
-gVr
-gaL
-gaL
-jXh
-gVr
-kZw
-kZw
-gaL
 mUf
 ghE
 xAc
@@ -53476,16 +53441,16 @@ jXh
 kjL
 sDQ
 gaL
+gaL
 jXh
+gVr
+gVr
+gVr
+gVr
+gVr
+gVr
+gVr
 ykB
-gVr
-jXh
-jXh
-gaL
-gVr
-fYQ
-kZw
-gaL
 mUf
 ghE
 pJX
@@ -53733,8 +53698,8 @@ gaL
 kjL
 taf
 gaL
+gaL
 jXh
-ykB
 nwc
 nwc
 nwc
@@ -53989,8 +53954,8 @@ gaL
 gaL
 kjL
 gaL
-jXh
-jXh
+gaL
+gaL
 ykB
 wUd
 cEs
@@ -54000,7 +53965,7 @@ xlt
 pTl
 cEs
 cEs
-eLw
+lwB
 xAc
 xAc
 mjD
@@ -54243,11 +54208,11 @@ hgd
 qjT
 jXh
 jXh
-jXh
+gaL
 kjL
 gaL
 jXh
-jXh
+gaL
 ykB
 mUf
 ghE
@@ -54500,7 +54465,7 @@ hgd
 bYc
 jXh
 jXh
-jXh
+gaL
 kjL
 cjN
 jXh
@@ -54757,7 +54722,7 @@ hgd
 bYc
 gaL
 jXh
-jXh
+gaL
 kjL
 jXh
 jXh
@@ -55770,8 +55735,8 @@ qto
 qto
 qto
 qto
-uka
-uka
+qto
+sXb
 jyh
 mdv
 aRt
@@ -56026,9 +55991,9 @@ aRt
 cLw
 cLw
 cLw
+qto
+qto
 kkI
-wHY
-xAc
 mSS
 xAc
 xAc
@@ -56283,9 +56248,9 @@ aQW
 cLw
 cLw
 wBg
+qto
+qto
 kkI
-xAc
-xAc
 wHY
 xAc
 wHY
@@ -57770,7 +57735,7 @@ dmf
 akK
 sSr
 xOq
-nFf
+kZw
 pbp
 vrA
 vrA
@@ -59312,7 +59277,7 @@ lqi
 lqi
 lqi
 lvu
-nFf
+pkQ
 lMO
 pbp
 lMO
@@ -59826,7 +59791,7 @@ vSu
 hle
 ocX
 xOq
-nFf
+kZw
 pbp
 vrA
 tHr
@@ -60083,7 +60048,7 @@ ehT
 slO
 gum
 xOq
-nFf
+pkQ
 pbp
 vrA
 pbp
@@ -60854,7 +60819,7 @@ ojh
 acj
 jQj
 lBx
-nFf
+kZw
 lMO
 pbp
 pbp
@@ -61111,7 +61076,7 @@ ehT
 ehT
 odP
 lBx
-vfB
+pkQ
 lMO
 pbp
 lMO
@@ -61625,7 +61590,7 @@ acj
 ava
 ocX
 lBx
-nFf
+kZw
 lMO
 pbp
 pbp
@@ -61882,7 +61847,7 @@ aiD
 eQe
 gvG
 lBx
-nFf
+pkQ
 lMO
 itF
 pbp
@@ -62396,7 +62361,7 @@ kwt
 kwt
 gem
 fhf
-nFf
+kZw
 uHQ
 lMO
 mRP


### PR DESCRIPTION
## About The Pull Request

- moves the ghost spawn from the brotherhood base to the center of the town
- removes all static landmines from every surface map
- genericizes heaven's night by removing khan branding
- changes heaven's night signage to the chiken ranch, along with minor aesthetic improvements 
- removes the 30minute time gates from the enclave and BoS bases
- fixes an uncountable amount of tiling errors with asphalt road shading and erosion
- restores the broken bridge in the NCR map
- numerous other tiny fixes that nobody but me will notice
