### PR TITLE
Adjustment to NCR adjacent firearms: Medicine Stick, 7.62, 50 cal adjustments

### DIFF
--- a/code/modules/projectiles/guns/ballistic/rifle.dm
+++ b/code/modules/projectiles/guns/ballistic/rifle.dm
@@ -150,7 +150,7 @@
 	fire_delay = 2.25
 	recoil = 0.10
 	fire_sound = 'sound/f13weapons/brushgunfire.ogg'
-	extra_penetration = 0.4
+	extra_penetration = 0.15
 
 
 ////////////////////////

--- a/code/modules/projectiles/guns/ballistic/rifle.dm
+++ b/code/modules/projectiles/guns/ballistic/rifle.dm
@@ -347,13 +347,6 @@
 	..()
 	if(HAS_TRAIT(user, TRAIT_FAST_PUMP))
 		src.pump(user)
-	if((prob(95) && !zoomed))
-		var/mob/living/carbon/human/H = user
-		playsound(loc, 'sound/f13effects/surrender.ogg', 100, 1)
-		shake_camera(user, recoil + 1, recoil)
-		to_chat(user, "<span class ='danger'>You attempt to fire the rifle from the hip unprepared, tossing you to the ground!</span>")
-		H.visible_message("<span class='danger'>[H] drops to the floor from recoil as they fire unprepared!</span>")
-		user.Knockdown(60)
 
 // BETA // Obsolete
 /obj/item/gun/ballistic/rifle/rifletesting

--- a/code/modules/projectiles/projectile/bullets/rifle.dm
+++ b/code/modules/projectiles/projectile/bullets/rifle.dm
@@ -147,8 +147,8 @@ heavy rifle calibers (12.7, 14mm, 7.62): Uranium, Contaminated, Incin
 /////////			-Very heavy rifle round.
 
 /obj/item/projectile/bullet/a50MG
-	damage = 38
-	armour_penetration = 0.75
+	damage = 40
+	armour_penetration = 0.85
 	pixels_per_second = 4000
 	zone_accuracy_factor = 100
 	wound_bonus = 30

--- a/code/modules/projectiles/projectile/bullets/rifle.dm
+++ b/code/modules/projectiles/projectile/bullets/rifle.dm
@@ -102,6 +102,7 @@ heavy rifle calibers (12.7, 14mm, 7.62): Uranium, Contaminated, Incin
 	damage = 34
 	wound_bonus = 28
 	bare_wound_bonus = 24
+	armour_penetration = 0.12
 
 //.308 Winchester
 /obj/item/projectile/bullet/a762/sport
@@ -146,13 +147,13 @@ heavy rifle calibers (12.7, 14mm, 7.62): Uranium, Contaminated, Incin
 /////////			-Very heavy rifle round.
 
 /obj/item/projectile/bullet/a50MG
-	damage = 75
-	armour_penetration = 1
+	damage = 38
+	armour_penetration = 0.75
 	pixels_per_second = 4000
 	zone_accuracy_factor = 100
-	wound_bonus = 60
-	bare_wound_bonus = 80//Same as the HMG.
-	supereffective_damage = 125
+	wound_bonus = 30
+	bare_wound_bonus = 40//Same as the HMG.
+	supereffective_damage = 62
 	supereffective_faction = list("hostile", "ant", "supermutant", "deathclaw", "cazador", "raider", "china", "gecko", "wastebot", "radscorpion")
 
 /obj/item/projectile/bullet/a50MG/incendiary

--- a/code/modules/projectiles/projectile/bullets/rifle.dm
+++ b/code/modules/projectiles/projectile/bullets/rifle.dm
@@ -102,7 +102,7 @@ heavy rifle calibers (12.7, 14mm, 7.62): Uranium, Contaminated, Incin
 	damage = 34
 	wound_bonus = 28
 	bare_wound_bonus = 24
-	armour_penetration = 0.12
+	armour_penetration = 0.35
 
 //.308 Winchester
 /obj/item/projectile/bullet/a762/sport

--- a/code/modules/projectiles/projectile/bullets/rifle.dm
+++ b/code/modules/projectiles/projectile/bullets/rifle.dm
@@ -153,7 +153,7 @@ heavy rifle calibers (12.7, 14mm, 7.62): Uranium, Contaminated, Incin
 	zone_accuracy_factor = 100
 	wound_bonus = 30
 	bare_wound_bonus = 40//Same as the HMG.
-	supereffective_damage = 62
+	supereffective_damage = 60
 	supereffective_faction = list("hostile", "ant", "supermutant", "deathclaw", "cazador", "raider", "china", "gecko", "wastebot", "radscorpion")
 
 /obj/item/projectile/bullet/a50MG/incendiary


### PR DESCRIPTION
Makes medicine stick a bit more sane, gives 7.62 back it's armor pen, and makes 50 cal not insanely OP

Removes AMR knockdown.