### PR TITLE
ion rifle pve buff

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/f13/wastebots.dm
+++ b/code/modules/mob/living/simple_animal/hostile/f13/wastebots.dm
@@ -351,12 +351,6 @@
 	aggrosound = FALSE
 	idlesound = FALSE
 
-/mob/living/simple_animal/hostile/handy/assaultron/nsb //NSB + Raider Bunker specific.
-	name = "assaultron"
-	aggro_vision_range = 15
-	faction = list("raider")
-	obj_damage = 300
-
 /mob/living/simple_animal/hostile/handy/assaultron/playable
 	see_in_dark = 8
 	force_threshold = 15

--- a/code/modules/projectiles/projectile/special/ion.dm
+++ b/code/modules/projectiles/projectile/special/ion.dm
@@ -6,6 +6,8 @@
 	damage_type = BURN
 	flag = "energy"
 	impact_effect_type = /obj/effect/temp_visual/impact_effect/ion
+	supereffective_damage = 36
+	supereffective_faction = list("wastebot")
 	var/emp_radius = 2
 
 /obj/item/projectile/ion/on_hit(atom/target, blocked = FALSE)


### PR DESCRIPTION


## About The Pull Request

ion rifle now does 50 damage against wastebot mobs

## Why It's Good For The Game

it's thematic and also gives it a use other than 'we're fighting BoS'

## Pre-Merge Checklist
- [ ] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [ ] You documented all of your changes.


## Changelog

:cl:
balance: ion rifle damage against bot mobs 24 >> 50
/:cl:

