### PR TITLE
map hotfix (chiken ranch doors, brotherhood airlock)

### DIFF
--- a/_maps/map_files/Pahrump-Sunset/Pahrump-Sunset-Lower.dmm
+++ b/_maps/map_files/Pahrump-Sunset/Pahrump-Sunset-Lower.dmm
@@ -6100,8 +6100,13 @@
 	},
 /area/f13/tunnel)
 "cyX" = (
-/obj/machinery/iv_drip,
-/obj/machinery/iv_drip,
+/obj/structure/table,
+/obj/item/clothing/gloves/color/latex,
+/obj/item/clothing/gloves/color/latex,
+/obj/item/clothing/gloves/color/latex,
+/obj/item/clothing/gloves/color/latex,
+/obj/item/clothing/gloves/color/latex,
+/obj/item/clothing/gloves/color/latex,
 /turf/open/floor/f13{
 	icon_state = "floorrustysolid"
 	},
@@ -7276,13 +7281,11 @@
 /turf/open/floor/plating,
 /area/f13/tunnel/bighorn)
 "ehp" = (
-/obj/machinery/light{
-	dir = 1
+/obj/machinery/iv_drip,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
 	},
-/turf/open/floor/plasteel/darkred/side{
-	dir = 9
-	},
-/area/f13/brotherhood)
+/area/f13/followers)
 "eii" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/darkred/side{
@@ -11035,6 +11038,14 @@
 /obj/effect/decal/cleanable/vomit,
 /turf/closed/mineral/random/low_chance,
 /area/f13/caves)
+"jNV" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/plasteel/darkred/side{
+	dir = 9
+	},
+/area/f13/brotherhood)
 "jOo" = (
 /obj/item/flag/bos{
 	density = 0
@@ -19866,6 +19877,7 @@
 /obj/machinery/light{
 	dir = 4
 	},
+/obj/machinery/iv_drip,
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
 	},
@@ -42318,7 +42330,7 @@ myk
 pHi
 uAZ
 wHC
-yle
+ehp
 cyX
 yjR
 wZj
@@ -75701,7 +75713,7 @@ onW
 onW
 oVq
 oVq
-ehp
+jNV
 mIf
 mIf
 wZq

--- a/_maps/map_files/Pahrump-Sunset/Pahrump-Sunset-Lower.dmm
+++ b/_maps/map_files/Pahrump-Sunset/Pahrump-Sunset-Lower.dmm
@@ -7276,8 +7276,11 @@
 /turf/open/floor/plating,
 /area/f13/tunnel/bighorn)
 "ehp" = (
-/turf/open/floor/plasteel/darkbrown/side{
-	dir = 8
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/plasteel/darkred/side{
+	dir = 9
 	},
 /area/f13/brotherhood)
 "eii" = (
@@ -74671,8 +74674,8 @@ aJq
 oVq
 oVq
 oVq
-nZR
-nZR
+oVq
+oVq
 uyb
 uyb
 uyb
@@ -74927,9 +74930,9 @@ ciN
 aJq
 oVq
 aVt
-tau
-ehp
-ehp
+fta
+fta
+fta
 tau
 fta
 fta
@@ -75698,7 +75701,7 @@ onW
 onW
 oVq
 oVq
-ixJ
+ehp
 mIf
 mIf
 wZq

--- a/_maps/map_files/Pahrump-Sunset/Pahrump-Sunset.dmm
+++ b/_maps/map_files/Pahrump-Sunset/Pahrump-Sunset.dmm
@@ -3690,7 +3690,7 @@
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
 	},
-/obj/machinery/door/unpowered/securedoor/khandoor,
+/obj/machinery/door/unpowered/securedoor,
 /turf/open/floor/carpet/red,
 /area/f13/bar/heaven)
 "aoD" = (
@@ -8083,7 +8083,7 @@
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
 	},
-/obj/machinery/door/unpowered/securedoor/khandoor,
+/obj/machinery/door/unpowered/securedoor,
 /turf/open/floor/wood/wood_mosaic/wood_mosaic_dark,
 /area/f13/bar/heaven)
 "aEl" = (
@@ -10597,7 +10597,7 @@
 /turf/open/indestructible/ground/outside/ruins,
 /area/f13/wasteland/west)
 "aMI" = (
-/obj/machinery/door/unpowered/securedoor/khandoor,
+/obj/machinery/door/unpowered/securedoor,
 /turf/open/floor/wood/wood_mosaic/wood_mosaic_dark,
 /area/f13/bar/heaven)
 "aMJ" = (
@@ -13958,7 +13958,7 @@
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
 	},
-/obj/machinery/door/unpowered/securedoor/khandoor,
+/obj/machinery/door/unpowered/securedoor,
 /turf/open/floor/plasteel/f13,
 /area/f13/bar/heaven)
 "aXY" = (
@@ -29688,11 +29688,11 @@
 	},
 /area/f13/wasteland/firestation)
 "gqr" = (
-/obj/item/cigbutt/cigarbutt{
-	pixel_x = -4;
-	pixel_y = -2
-	},
+/obj/machinery/light/floor,
 /obj/structure/table/wood/settler,
+/obj/item/cigbutt/cigarbutt{
+	pixel_x = 1
+	},
 /turf/open/floor/carpet/red,
 /area/f13/bar/heaven)
 "gqs" = (
@@ -73611,7 +73611,7 @@ aHz
 gKb
 aXW
 aXW
-aXX
+bbB
 aXW
 baU
 bbB
@@ -76191,7 +76191,7 @@ oYn
 axZ
 sdg
 sdg
-aMV
+gqr
 cJN
 aXW
 hqc
@@ -76445,7 +76445,7 @@ baA
 baA
 gft
 mSq
-gqr
+axZ
 sdg
 sdg
 axZ

--- a/_maps/map_files/Pahrump-Sunset/Pahrump-Sunset.dmm
+++ b/_maps/map_files/Pahrump-Sunset/Pahrump-Sunset.dmm
@@ -293,7 +293,6 @@
 /obj/machinery/light/small{
 	dir = 1
 	},
-/obj/effect/landmark/start/f13/khan_court,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/building)
 "abh" = (
@@ -33931,9 +33930,6 @@
 	},
 /area/f13/building)
 "iUv" = (
-/obj/structure/flora/tree/tall{
-	icon_state = "tree_2"
-	},
 /obj/structure/railing/corner{
 	dir = 1
 	},
@@ -57694,11 +57690,6 @@
 /obj/structure/showcase/horrific_experiment,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/building/museum)
-"wWm" = (
-/obj/effect/overlay/rockfloor_side,
-/obj/effect/landmark/start/f13/khan_court,
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/building)
 "wWt" = (
 /obj/structure/chair,
 /obj/effect/decal/cleanable/dirt{
@@ -99680,7 +99671,7 @@ qmV
 xyU
 xyU
 ffb
-wWm
+abI
 uaU
 qeT
 dAO

--- a/_maps/map_files/Pahrump-Sunset/Warren.dmm
+++ b/_maps/map_files/Pahrump-Sunset/Warren.dmm
@@ -704,6 +704,9 @@
 	},
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland/warren)
+"aDL" = (
+/turf/closed/wall/f13/supermart,
+/area/f13/caves)
 "aEg" = (
 /obj/machinery/light/broken{
 	dir = 1
@@ -4525,6 +4528,22 @@
 	dir = 4
 	},
 /area/f13/wasteland/warren)
+"emT" = (
+/obj/structure/closet/cabinet,
+/obj/item/clothing/under/f13/ncr/conscript,
+/obj/item/clothing/under/f13/ncr/conscript,
+/obj/item/clothing/under/f13/ncr/conscript,
+/obj/item/clothing/under/f13/ncr/conscript,
+/obj/item/clothing/under/f13/ncr/conscript,
+/obj/item/clothing/under/f13/ncr/conscript,
+/obj/item/clothing/under/f13/ncr/conscript,
+/obj/item/clothing/under/f13/ncr/conscript,
+/obj/item/clothing/under/f13/ncr/conscript,
+/obj/item/clothing/under/f13/ncr/conscript,
+/turf/open/floor/plasteel/f13/vault_floor/dark{
+	icon_state = "darkdirty"
+	},
+/area/f13/ncr)
 "ena" = (
 /obj/structure/sign/poster/prewar/poster72,
 /turf/closed/wall/f13/vault{
@@ -7250,6 +7269,14 @@
 	icon_state = "darkdirtysolid"
 	},
 /area/f13/ncr)
+"gLV" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/ncr)
 "gMe" = (
 /obj/structure/table/wood,
 /turf/open/indestructible/ground/outside/sidewalk,
@@ -7262,12 +7289,19 @@
 	},
 /area/f13/city)
 "gMI" = (
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/structure/barricade/bars,
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
+/obj/structure/closet/cabinet,
+/obj/item/clothing/under/f13/ncr/ncr_shorts,
+/obj/item/clothing/under/f13/ncr/ncr_shorts,
+/obj/item/clothing/under/f13/ncr/ncr_shorts,
+/obj/item/clothing/under/f13/ncr/ncr_shorts,
+/obj/item/clothing/under/f13/ncr/ncr_shorts,
+/obj/item/clothing/under/f13/ncr/pants,
+/obj/item/clothing/under/f13/ncr/pants,
+/obj/item/clothing/under/f13/ncr/pants,
+/obj/item/clothing/under/f13/ncr/pants,
+/obj/item/clothing/under/f13/ncr/pants,
+/turf/open/floor/plasteel/f13/vault_floor/dark{
+	icon_state = "darkdirty"
 	},
 /area/f13/ncr)
 "gNp" = (
@@ -20778,6 +20812,16 @@
 /obj/effect/decal/cleanable/glass,
 /turf/open/indestructible/ground/outside/savannah/bottomleft,
 /area/f13/wasteland/warren)
+"tLz" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/ncr)
 "tLN" = (
 /obj/structure/reagent_dispensers/barrel/explosive{
 	pixel_x = -7
@@ -20803,6 +20847,23 @@
 	},
 /turf/open/indestructible/ground/outside/sidewalk,
 /area/f13/city)
+"tMz" = (
+/obj/structure/closet/cabinet,
+/obj/item/clothing/under/f13/ncr,
+/obj/item/clothing/under/f13/ncr,
+/obj/item/clothing/under/f13/ncr,
+/obj/item/clothing/under/f13/ncr,
+/obj/item/clothing/under/f13/ncr,
+/obj/item/clothing/under/f13/ncr,
+/obj/item/clothing/under/f13/ncr,
+/obj/item/clothing/under/f13/ncr,
+/obj/item/clothing/under/f13/ncr,
+/obj/item/clothing/under/f13/ncr,
+/obj/machinery/light/small,
+/turf/open/floor/plasteel/f13/vault_floor/dark{
+	icon_state = "darkdirty"
+	},
+/area/f13/ncr)
 "tMG" = (
 /obj/machinery/smartfridge/bottlerack/drug_storage,
 /obj/effect/spawner/lootdrop/f13/bomb/tier1,
@@ -22980,6 +23041,15 @@
 	icon_state = "horizontaloutermain1"
 	},
 /area/f13/wasteland/warren)
+"vCM" = (
+/obj/structure/closet/crate{
+	anchored = 1;
+	can_be_unanchored = 1
+	},
+/obj/effect/spawner/lootdrop/f13/ncr_k_ration,
+/obj/machinery/light/small,
+/turf/open/floor/f13/wood,
+/area/f13/ncr)
 "vCO" = (
 /obj/structure/barricade/tentclothedge{
 	dir = 8;
@@ -46581,15 +46651,15 @@ nkj
 uAm
 nkj
 nkj
-gMI
+hTM
 jAX
+tLz
 laS
-laS
 nkj
 nkj
-gMI
+hTM
 nkj
-nkj
+gLV
 nkj
 nkj
 plH
@@ -60730,7 +60800,7 @@ xaA
 otG
 rPr
 goE
-pLS
+goE
 qZx
 qZx
 "}
@@ -60986,8 +61056,8 @@ xQr
 baC
 guq
 lrJ
+gMI
 goE
-pLS
 qZx
 qZx
 "}
@@ -61243,8 +61313,8 @@ lrJ
 nRO
 lrJ
 lrJ
+tMz
 goE
-pLS
 qZx
 qZx
 "}
@@ -61496,12 +61566,12 @@ cJB
 lrJ
 nRO
 goE
-wMp
-rYD
-ggv
-gXJ
+nRO
+nRO
+nRO
+nRO
+emT
 goE
-pLS
 qZx
 qZx
 "}
@@ -61753,12 +61823,12 @@ cJB
 lrJ
 icS
 goE
+wMp
+rYD
+ggv
+gXJ
 goE
 goE
-goE
-goE
-goE
-pLS
 pLS
 qZx
 "}
@@ -62010,10 +62080,10 @@ goE
 vhR
 nRO
 goE
-dKQ
-rjq
-qFq
-xeU
+goE
+goE
+goE
+goE
 goE
 pLS
 pLS
@@ -62266,11 +62336,11 @@ cJB
 ehI
 nRO
 lrJ
-hpn
+goE
+dKQ
+rjq
 qFq
-qFq
-qFq
-wFO
+xeU
 goE
 pLS
 pLS
@@ -62523,11 +62593,11 @@ cJB
 erv
 nRO
 lrJ
-goE
-ybe
+hpn
 qFq
 qFq
-wFO
+qFq
+vCM
 goE
 pLS
 pLS
@@ -62781,10 +62851,10 @@ goE
 nRO
 nRO
 goE
-xeU
+ybe
 qFq
 qFq
-xeU
+wFO
 goE
 pLS
 pLS
@@ -63038,10 +63108,10 @@ goE
 duQ
 goE
 goE
-goE
-goE
-goE
-goE
+xeU
+qFq
+qFq
+xeU
 goE
 pLS
 pLS
@@ -63295,11 +63365,11 @@ xzR
 cJB
 uPe
 goE
-pLS
-pLS
-pLS
-pLS
-pLS
+aDL
+aDL
+aDL
+aDL
+aDL
 pLS
 qZx
 qZx


### PR DESCRIPTION
## About The Pull Request

- adds six sets of latex gloves to the downstairs area of the followers
- adds closets for spare NCR uniforms (desert fatigues, conscript fatigues, shorts and pants) in the NCR wardrobe
- fixes an oversight with the doors in the chicken ranch being restricted to khan access
- fixes the airlocks leading to a rock wall in the BoS bunker
- deletes a single dead tree in the khan base
