### PR TITLE
Fixes Rocket Launcher and Grenade Launcher empty sprite code

### DIFF
--- a/code/modules/projectiles/guns/ballistic/launchers.dm
+++ b/code/modules/projectiles/guns/ballistic/launchers.dm
@@ -13,10 +13,30 @@
 	weapon_weight = WEAPON_HEAVY
 	pin = /obj/item/firing_pin
 
+/obj/item/gun/ballistic/revolver/grenadelauncher/attack_self(mob/living/user)
+	var/num_unloaded = 0
+	chambered = null
+	while (get_ammo() > 0)
+		var/obj/item/ammo_casing/CB
+		CB = magazine.get_round(0)
+		if(CB)
+			CB.forceMove(drop_location())
+			CB.bounce_away(FALSE, NONE)
+			num_unloaded++
+	if (num_unloaded)
+		to_chat(user, "<span class='notice'>You unload [num_unloaded] shell\s from [src].</span>")
+		update_icon()
+	else
+		to_chat(user, "<span class='warning'>[src] is empty!</span>")
+
 /obj/item/gun/ballistic/revolver/grenadelauncher/attackby(obj/item/A, mob/user, params)
 	..()
 	if(istype(A, /obj/item/ammo_box) || istype(A, /obj/item/ammo_casing))
 		chamber_round()
+		update_icon()
+
+/obj/item/gun/ballistic/revolver/grenadelauncher/update_icon_state()
+	icon_state = "[initial(icon_state)]-[chambered ? "1" : "e"]"
 
 /obj/item/gun/ballistic/revolver/grenadelauncher/cyborg
 	desc = "A 6-shot grenade launcher."
@@ -140,7 +160,7 @@
 			update_icon()
 
 /obj/item/gun/ballistic/rocketlauncher/update_icon_state()
-	icon_state = "[initial(icon_state)]-[chambered ? "1" : "0"]"
+	icon_state = "[initial(icon_state)]-[chambered ? "1" : "e"]"
 
 /obj/item/gun/ballistic/rocketlauncher/suicide_act(mob/living/user)
 	user.visible_message("<span class='warning'>[user] aims [src] at the ground! It looks like [user.p_theyre()] performing a sick rocket jump!</span>", \


### PR DESCRIPTION
## About The Pull Request
As grenade launchers use revolver code, they don't update sprites on unload and reload. This fixes that, as well as changing the suffix for empty rocket launchers to be '-e' instead of '-0', bringing it in line with other firearms with empty sprites.

## Why It's Good For The Game

Makes rocket launcher and grenade launcher empty sprites not redundant.

## Pre-Merge Checklist
<!-- Don't bother filling these in while creating your Pull Request, just click the checkboxes after the Pull Request is opened and you are redirected to the page. -->
- [ ] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [ ] You documented all of your changes.
<!-- Neither the compiler nor workflow checks are perfect at detecting runtimes and errors. It is important to test your code/feature/fix locally. -->


## Changelog
<!-- This is mostly optional for small Pull Requests, but if you value being credited for your work in-game be sure to fill it out. To opt-out, remove everything below including the start and end :cl: brackets. -->

<!-- If your Pull Request includes a minor single line variable edit, probably do not fill out this changelog. -->
<!-- However, if your pull request includes massive or immediately noticeable changes, briefly describe those changes in some way in this changelog. -->

:cl:
add: Var for grenade launcher reloads to update sprites
tweak: Adjusted rocket launcher empty sprite suffix from '-0' to '-e'
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
